### PR TITLE
Fix RuntimeException after Toast call in a non-main thread

### DIFF
--- a/app/src/main/java/me/zhanghai/android/files/util/AppUtils.java
+++ b/app/src/main/java/me/zhanghai/android/files/util/AppUtils.java
@@ -89,7 +89,7 @@ public class AppUtils {
             return true;
         } catch (ActivityNotFoundException | IllegalArgumentException e) {
             e.printStackTrace();
-            ToastUtils.show(R.string.activity_not_found, context);
+            AppUtils.runOnUiThread(() -> ToastUtils.show(R.string.activity_not_found, context));
             return false;
         }
     }
@@ -100,7 +100,7 @@ public class AppUtils {
             return true;
         } catch (ActivityNotFoundException | IllegalArgumentException e) {
             e.printStackTrace();
-            ToastUtils.show(R.string.activity_not_found, fragment.requireContext());
+            AppUtils.runOnUiThread(() -> ToastUtils.show(R.string.activity_not_found, fragment.requireContext()));
             return false;
         }
     }
@@ -112,7 +112,7 @@ public class AppUtils {
             return true;
         } catch (ActivityNotFoundException | IllegalArgumentException e) {
             e.printStackTrace();
-            ToastUtils.show(R.string.activity_not_found, activity);
+            AppUtils.runOnUiThread(() -> ToastUtils.show(R.string.activity_not_found, activity));
             return false;
         }
     }
@@ -124,7 +124,7 @@ public class AppUtils {
             return true;
         } catch (ActivityNotFoundException | IllegalArgumentException e) {
             e.printStackTrace();
-            ToastUtils.show(R.string.activity_not_found, fragment.requireContext());
+            AppUtils.runOnUiThread(() -> ToastUtils.show(R.string.activity_not_found, fragment.requireContext()));
             return false;
         }
     }


### PR DESCRIPTION
Hi. In some cases, this code is called in a non-main thread and we get  `RuntimeException: Can't toast on a thread that has not called Looper.prepare()`. I came across this when I tried to open the RAR archive, but I didn't have app that could open it. Instead of `No application found to handle this action` toast, I got `Can't toast on a thread that has not called Looper.prepare()` toast. FileJobs.java:1879 line was specified on the stack trace.
P.S: I see that you are converting the project into Kotlin, I think that is a similar problem in there.