### PR TITLE
Add checksums in file properties

### DIFF
--- a/app/src/main/java/me/zhanghai/android/files/fileproperties/FilePropertiesDialogFragment.kt
+++ b/app/src/main/java/me/zhanghai/android/files/fileproperties/FilePropertiesDialogFragment.kt
@@ -21,6 +21,7 @@ import me.zhanghai.android.files.filelist.name
 import me.zhanghai.android.files.fileproperties.apk.FilePropertiesApkTabFragment
 import me.zhanghai.android.files.fileproperties.audio.FilePropertiesAudioTabFragment
 import me.zhanghai.android.files.fileproperties.basic.FilePropertiesBasicTabFragment
+import me.zhanghai.android.files.fileproperties.checksums.FilePropertiesChecksumsTabFragment
 import me.zhanghai.android.files.fileproperties.image.FilePropertiesImageTabFragment
 import me.zhanghai.android.files.fileproperties.permissions.FilePropertiesPermissionsTabFragment
 import me.zhanghai.android.files.fileproperties.video.FilePropertiesVideoTabFragment
@@ -106,6 +107,13 @@ class FilePropertiesDialogFragment : AppCompatDialogFragment() {
                                 FilePropertiesApkTabFragment.Args(args.file.path)
                             )
                         }
+                    )
+                }
+                if (FilePropertiesChecksumsTabFragment.isAvailable(args.file)) {
+                    add(
+                            R.string.file_properties_checksums to {
+                                FilePropertiesChecksumsTabFragment()
+                            }
                     )
                 }
             }

--- a/app/src/main/java/me/zhanghai/android/files/fileproperties/checksums/FilePropertiesChecksumsTabFragment.kt
+++ b/app/src/main/java/me/zhanghai/android/files/fileproperties/checksums/FilePropertiesChecksumsTabFragment.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2018 Hai Zhang <dreaming.in.code.zh@gmail.com>
+ * Copyright 2020 Panagiotis Panagiotopoulos <panagiotopoulos.git@gmail.com>
+ * All Rights Reserved.
+ */
+
+package me.zhanghai.android.files.fileproperties.checksums
+
+import android.os.Bundle
+import androidx.lifecycle.observe
+import kotlinx.android.synthetic.main.file_properties_tab_item.view.*
+import me.zhanghai.android.files.R
+import me.zhanghai.android.files.file.FileItem
+import me.zhanghai.android.files.fileproperties.FilePropertiesFileViewModel
+import me.zhanghai.android.files.fileproperties.FilePropertiesTabFragment
+import me.zhanghai.android.files.util.Stateful
+import me.zhanghai.android.files.util.viewModels
+import java.io.FileInputStream
+import java.security.MessageDigest
+
+class FilePropertiesChecksumsTabFragment : FilePropertiesTabFragment() {
+    private val viewModel by viewModels<FilePropertiesFileViewModel>({ requireParentFragment() })
+
+    override fun onActivityCreated(savedInstanceState: Bundle?) {
+        super.onActivityCreated(savedInstanceState)
+
+        viewModel.fileLiveData.observe(viewLifecycleOwner) { onFileChanged(it) }
+    }
+
+    override fun refresh() {
+        viewModel.reload()
+    }
+
+    private fun onFileChanged(stateful: Stateful<FileItem>) {
+        bindView(stateful) { file ->
+            addItemView(
+                    R.string.file_properties_checksums_md5,
+                    ""
+            ) {
+                if(it.textText.text.isNullOrEmpty())
+                    it.textText.setText(getFileHash(file.path.toString(), "MD5"))
+            }
+            addItemView(
+                    R.string.file_properties_checksums_sha1,
+                    ""
+            ) {
+                if(it.textText.text.isNullOrEmpty())
+                    it.textText.setText(getFileHash(file.path.toString(), "SHA-1"))
+            }
+            addItemView(
+                    R.string.file_properties_checksums_sha256,
+                    ""
+            ) {
+                if(it.textText.text.isNullOrEmpty())
+                    it.textText.setText(getFileHash(file.path.toString(), "SHA-256"))
+            }
+        }
+    }
+
+    private fun getFileHash(filePath: String, algorithm: String): String {
+        val md = MessageDigest.getInstance(algorithm)
+        val fis = FileInputStream(filePath)
+        val buffer = ByteArray(8192)
+        var read: Int
+        while (fis.read(buffer).also { read = it } > 0) {
+            md.update(buffer, 0, read)
+        }
+        fis.close()
+        return md.digest().toHex()
+    }
+
+    private fun ByteArray.toHex(): String {
+        return joinToString("") { "%02x".format(it) }
+    }
+
+    companion object {
+        fun isAvailable(file: FileItem): Boolean = file.attributes.isRegularFile
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -464,6 +464,10 @@
     </string-array>
     <string name="file_properties_apk_signature_digests">Signatures</string>
     <string name="file_properties_apk_past_signature_digests">Old signatures</string>
+    <string name="file_properties_checksums">Checksums</string>
+    <string name="file_properties_checksums_md5">MD5</string>
+    <string name="file_properties_checksums_sha1">SHA1</string>
+    <string name="file_properties_checksums_sha256">SHA256</string>
 
     <string name="navigation_root_directory">Root</string>
     <string name="navigation_root_subtitle_format">%1$s free of %2$s</string>


### PR DESCRIPTION
Added a tab in file properties to check a file's checksum (MD5, SHA-1 and SHA-256).
Hashes are calculated when user clicks on the appropriate text area.
Closes #48 

![checksums_preview](https://user-images.githubusercontent.com/62523576/83665928-aa215500-a5bb-11ea-928a-f8c9afa60010.png)

Idea for future functionality: Text input to paste hash from clipboard and attempt to match against file's checksums (example: KDE's Dolphin File Manager).