### PR TITLE
[Feature] Make drawer can be dragged out in fullscreen

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -161,6 +161,7 @@ dependencies {
     implementation 'org.apache.ftpserver:ftpserver-core:1.1.1'
     // Also a dependency of jCIFS-NG and Junrar.
     implementation 'org.slf4j:slf4j-android:1.7.30'
+    implementation 'com.drakeet.drawer:drawer:1.0.2'
 
 //#ifdef NONFREE
     implementation 'com.google.firebase:firebase-analytics:18.0.0'

--- a/app/src/main/java/me/zhanghai/android/files/ui/PersistentBarLayout.kt
+++ b/app/src/main/java/me/zhanghai/android/files/ui/PersistentBarLayout.kt
@@ -11,21 +11,21 @@ import android.view.Gravity
 import android.view.View
 import android.view.ViewGroup
 import android.view.WindowInsets
+import android.widget.FrameLayout
 import androidx.annotation.AttrRes
-import androidx.annotation.StyleRes
 import androidx.core.content.res.use
 import androidx.core.view.children
 import androidx.core.view.isInvisible
 import androidx.customview.widget.ViewDragHelper
+import com.drakeet.drawer.FullDraggableContainer
 import me.zhanghai.android.files.util.layoutInStatusBar
 
 /**
  * @see PersistentDrawerLayout
  */
 class PersistentBarLayout @JvmOverloads constructor(
-    context: Context, attrs: AttributeSet? = null,
-    @AttrRes defStyleAttr: Int = 0, @StyleRes defStyleRes: Int = 0
-) : ViewGroup(context, attrs, defStyleAttr, defStyleRes) {
+    context: Context, attrs: AttributeSet? = null, @AttrRes defStyleAttr: Int = 0
+) : FullDraggableContainer(context, attrs, defStyleAttr) {
     private val topDragger = ViewDragHelper.create(this, ViewDragCallback(Gravity.TOP))
     private val bottomDragger = ViewDragHelper.create(this, ViewDragCallback(Gravity.BOTTOM))
 
@@ -291,7 +291,7 @@ class PersistentBarLayout @JvmOverloads constructor(
         }
     }
 
-    override fun generateLayoutParams(attrs: AttributeSet?): ViewGroup.LayoutParams =
+    override fun generateLayoutParams(attrs: AttributeSet?): LayoutParams =
         LayoutParams(context, attrs)
 
     override fun generateLayoutParams(
@@ -303,7 +303,7 @@ class PersistentBarLayout @JvmOverloads constructor(
             else -> LayoutParams(layoutParams)
         }
 
-    override fun generateDefaultLayoutParams(): ViewGroup.LayoutParams =
+    override fun generateDefaultLayoutParams(): LayoutParams =
         LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT)
 
     override fun checkLayoutParams(layoutParams: ViewGroup.LayoutParams): Boolean =
@@ -500,8 +500,7 @@ class PersistentBarLayout @JvmOverloads constructor(
             }
     }
 
-    class LayoutParams : MarginLayoutParams {
-        var gravity = Gravity.NO_GRAVITY
+    class LayoutParams : FrameLayout.LayoutParams {
         var offset = 0f
         var isShown = false
 

--- a/app/src/main/java/me/zhanghai/android/files/ui/PersistentBarLayout.kt
+++ b/app/src/main/java/me/zhanghai/android/files/ui/PersistentBarLayout.kt
@@ -11,21 +11,21 @@ import android.view.Gravity
 import android.view.View
 import android.view.ViewGroup
 import android.view.WindowInsets
-import android.widget.FrameLayout
 import androidx.annotation.AttrRes
+import androidx.annotation.StyleRes
 import androidx.core.content.res.use
 import androidx.core.view.children
 import androidx.core.view.isInvisible
 import androidx.customview.widget.ViewDragHelper
-import com.drakeet.drawer.FullDraggableContainer
 import me.zhanghai.android.files.util.layoutInStatusBar
 
 /**
  * @see PersistentDrawerLayout
  */
 class PersistentBarLayout @JvmOverloads constructor(
-    context: Context, attrs: AttributeSet? = null, @AttrRes defStyleAttr: Int = 0
-) : FullDraggableContainer(context, attrs, defStyleAttr) {
+    context: Context, attrs: AttributeSet? = null,
+    @AttrRes defStyleAttr: Int = 0, @StyleRes defStyleRes: Int = 0
+) : ViewGroup(context, attrs, defStyleAttr, defStyleRes) {
     private val topDragger = ViewDragHelper.create(this, ViewDragCallback(Gravity.TOP))
     private val bottomDragger = ViewDragHelper.create(this, ViewDragCallback(Gravity.BOTTOM))
 
@@ -291,7 +291,7 @@ class PersistentBarLayout @JvmOverloads constructor(
         }
     }
 
-    override fun generateLayoutParams(attrs: AttributeSet?): LayoutParams =
+    override fun generateLayoutParams(attrs: AttributeSet?): ViewGroup.LayoutParams =
         LayoutParams(context, attrs)
 
     override fun generateLayoutParams(
@@ -303,7 +303,7 @@ class PersistentBarLayout @JvmOverloads constructor(
             else -> LayoutParams(layoutParams)
         }
 
-    override fun generateDefaultLayoutParams(): LayoutParams =
+    override fun generateDefaultLayoutParams(): ViewGroup.LayoutParams =
         LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT)
 
     override fun checkLayoutParams(layoutParams: ViewGroup.LayoutParams): Boolean =
@@ -500,7 +500,8 @@ class PersistentBarLayout @JvmOverloads constructor(
             }
     }
 
-    class LayoutParams : FrameLayout.LayoutParams {
+    class LayoutParams : MarginLayoutParams {
+        var gravity = Gravity.NO_GRAVITY
         var offset = 0f
         var isShown = false
 

--- a/app/src/main/res/layout/file_list_fragment_include.xml
+++ b/app/src/main/res/layout/file_list_fragment_include.xml
@@ -13,27 +13,33 @@
         android:layout_width="match_parent"
         android:fitsSystemWindows="true">
 
-        <me.zhanghai.android.files.ui.PersistentBarLayout
-            android:id="@+id/persistentBarLayout"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:fitsSystemWindows="true">
+        <com.drakeet.drawer.FullDraggableContainer
+          android:layout_width="match_parent"
+          android:layout_height="match_parent">
 
-            <androidx.coordinatorlayout.widget.CoordinatorLayout
+            <me.zhanghai.android.files.ui.PersistentBarLayout
+                android:id="@+id/persistentBarLayout"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:fitsSystemWindows="true">
 
-                <include layout="@layout/file_list_fragment_app_bar_include" />
+                <androidx.coordinatorlayout.widget.CoordinatorLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:fitsSystemWindows="true">
 
-                <include layout="@layout/file_list_fragment_content_include" />
+                    <include layout="@layout/file_list_fragment_app_bar_include" />
 
-            </androidx.coordinatorlayout.widget.CoordinatorLayout>
+                    <include layout="@layout/file_list_fragment_content_include" />
 
-            <include layout="@layout/file_list_fragment_bottom_bar_include"/>
+                </androidx.coordinatorlayout.widget.CoordinatorLayout>
 
-            <include layout="@layout/file_list_fragment_speed_dial_include" />
-        </me.zhanghai.android.files.ui.PersistentBarLayout>
+                <include layout="@layout/file_list_fragment_bottom_bar_include"/>
+
+                <include layout="@layout/file_list_fragment_speed_dial_include" />
+            </me.zhanghai.android.files.ui.PersistentBarLayout>
+
+        </com.drakeet.drawer.FullDraggableContainer>
 
         <me.zhanghai.android.files.ui.NavigationFrameLayout
             android:id="@+id/navigationFragment"

--- a/app/src/main/res/raw/licenses.xml
+++ b/app/src/main/res/raw/licenses.xml
@@ -195,4 +195,11 @@
         <copyright>Copyright 2003 The Apache Software Foundation</copyright>
         <license>Apache Software License 2.0</license>
     </notice>
+
+    <notice>
+        <name>FullDraggableDrawer</name>
+        <url>https://github.com/PureWriter/FullDraggableDrawer</url>
+        <copyright>Copyright 2021 Drakeet Xu</copyright>
+        <license>Apache Software License 2.0</license>
+    </notice>
 </notices>


### PR DESCRIPTION
With more and more Android phones today running systems that support edge gestures, the original `DrawerLayout` is prone to gesture conflicts in the process of being dragged out, resulting in exiting the application.

So this PR adds [FullDraggableDrawer](https://github.com/PureWriter/FullDraggableDrawer) to `DrawerLayout` and wraps `PersistentBarLayout` to make the drawer can be dragged out in fullscreen.

Resolved #429

Note: I have tried to make `PersistentBarLayout` extend `FullDraggableContainer` to avoid adding a new wrapper/layer layout, which can also achieve the same result, but I think this will destroy the purity and reusability of `PersistentBarLayout`, so I later reverted this approach.

**Preview:**

<img src ="https://user-images.githubusercontent.com/5214214/104087959-47eda880-529e-11eb-86fd-413f6b02215b.gif" width=240></img>