### PR TITLE
Fix the compatibility issue of android:gravity

### DIFF
--- a/app/src/main/res/drawable/color_swatch_view_background.xml
+++ b/app/src/main/res/drawable/color_swatch_view_background.xml
@@ -23,7 +23,11 @@
     </item>
     -->
 
-    <item android:gravity="center">
+    <item         
+        android:top="6dp"
+        android:bottom="6dp"
+        android:left="6dp"
+        android:right="6dp">
         <animated-selector
             android:enterFadeDuration="@android:integer/config_shortAnimTime"
             android:exitFadeDuration="@android:integer/config_shortAnimTime">


### PR DESCRIPTION
Hello,

I know you will not accept the PR for the copyright reason, but I still would like to open a pull request to show you the issue I have found and how you can fix it by yourself.

I found you use ``android:gravity`` in https://github.com/zhanghai/MaterialFiles/blob/e2df8651efa5a5c5e1a2bfc31928f989f6f45c1f/app/src/main/res/drawable/color_swatch_view_background.xml#L26

``android:gravity`` can cause a compatibility issue as it is not available at API Level < 23.

To reproduce it, click on "Settings", "Theme Color". You can see the tick mark is full of the button at API Level 22.

API Level 31
![2671659846641_ pic](https://user-images.githubusercontent.com/109571086/183275374-2ff07242-86d3-4d37-bf34-6986d648f233.jpg)

API Level 22
![2681659846967_ pic](https://user-images.githubusercontent.com/109571086/183275459-b1d4574c-ea79-4052-b894-14afaeead22b.jpg)

This PR actually helps fix this issue. We can use ``android:top``, ``android:bottom``, ``android:left`` and ``android:right``. 6dp is set because the button's width and height are 48dp and the tick mark's width and height should be 36dp. The issue has gone on my side.

Hope the information is helpful.
 