### PR TITLE
[Feature] Fast multiple selection via swipe gesture

### DIFF
--- a/app/src/main/java/me/zhanghai/android/files/filelist/FileListViewModel.kt
+++ b/app/src/main/java/me/zhanghai/android/files/filelist/FileListViewModel.kt
@@ -170,7 +170,8 @@ class FileListViewModel : ViewModel() {
             }
         }
         if (changed) {
-            _selectedFilesLiveData.value = selectedFiles
+            // Async setValue for background thread usage: https://stackoverflow.com/questions/53304347/mutablelivedata-cannot-invoke-setvalue-on-a-background-thread-from-coroutine
+            _selectedFilesLiveData.postValue(selectedFiles)
         }
     }
 


### PR DESCRIPTION
This is my attempt to implement a quality of life improvement regarding the selection of multiple files near each other.
Pressing an icon using list view and swiping upwards/downwards will interact with neighboring files and directories for a smooth multiple selection gesture.

Here is a demo:

https://github.com/zhanghai/MaterialFiles/assets/90446383/27785329-0511-478d-87ed-83174ff9358c


Hoping, if my PR won't get merged because of licensing issues, that it may nonetheless be an interesting concept for you to consider. Thank you for the time you've spent developing this amazing app!
