### PR TITLE
feat: ftp server support custom data transfer port in passive mode.

### DIFF
--- a/app/src/main/java/me/zhanghai/android/files/ftpserver/FtpServer.kt
+++ b/app/src/main/java/me/zhanghai/android/files/ftpserver/FtpServer.kt
@@ -7,6 +7,7 @@ package me.zhanghai.android.files.ftpserver
 
 import java8.nio.file.Path
 import org.apache.ftpserver.ConnectionConfigFactory
+import org.apache.ftpserver.DataConnectionConfigurationFactory
 import org.apache.ftpserver.FtpServer
 import org.apache.ftpserver.FtpServerFactory
 import org.apache.ftpserver.ftplet.FtpException
@@ -18,6 +19,7 @@ class FtpServer(
     private val username: String,
     private val password: String?,
     private val port: Int,
+    private val passiveDataPorts: String?,
     private val homeDirectory: Path,
     private val writable: Boolean
 ) {
@@ -28,8 +30,15 @@ class FtpServer(
         server = FtpServerFactory()
             .apply {
                 val listener = ListenerFactory()
-                    .apply { port = this@FtpServer.port }
-                    .createListener()
+                    .apply {
+                        port = this@FtpServer.port
+                        passiveDataPorts?.let {
+                            dataConnectionConfiguration = DataConnectionConfigurationFactory()
+                                .apply {
+                                    passivePorts = it
+                                }.createDataConnectionConfiguration()
+                        }
+                    }.createListener()
                 addListener("default", listener)
                 val user = BaseUser().apply {
                     name = username

--- a/app/src/main/java/me/zhanghai/android/files/ftpserver/FtpServerService.kt
+++ b/app/src/main/java/me/zhanghai/android/files/ftpserver/FtpServerService.kt
@@ -102,9 +102,12 @@ class FtpServerService : Service() {
             password = Settings.FTP_SERVER_PASSWORD.valueCompat
         }
         val port = Settings.FTP_SERVER_PORT.valueCompat
+        val passiveDataPort: String? = if (Settings.FTP_SERVER_CUSTOM_DATA_PORT.valueCompat) {
+            Settings.FTP_SERVER_DATA_PORT.valueCompat
+        } else null
         val homeDirectory = Settings.FTP_SERVER_HOME_DIRECTORY.valueCompat
         val writable = Settings.FTP_SERVER_WRITABLE.valueCompat
-        val server = FtpServer(username, password, port, homeDirectory, writable)
+        val server = FtpServer(username, password, port, passiveDataPort, homeDirectory, writable)
         this.server = server
         try {
             server.start()
@@ -153,9 +156,6 @@ class FtpServerService : Service() {
     }
 
     enum class State {
-        STARTING,
-        RUNNING,
-        STOPPING,
-        STOPPED
+        STARTING, RUNNING, STOPPING, STOPPED
     }
 }

--- a/app/src/main/java/me/zhanghai/android/files/settings/Settings.kt
+++ b/app/src/main/java/me/zhanghai/android/files/settings/Settings.kt
@@ -87,6 +87,17 @@ object Settings {
             R.string.pref_key_ftp_server_port, R.integer.pref_default_value_ftp_server_port
         )
 
+    val FTP_SERVER_CUSTOM_DATA_PORT: SettingLiveData<Boolean> =
+        BooleanSettingLiveData(
+            R.string.pref_key_ftp_server_custom_data_port,
+            R.bool.pref_default_value_ftp_server_custom_data_port
+        )
+
+    val FTP_SERVER_DATA_PORT: SettingLiveData<String> =
+        StringSettingLiveData(
+            R.string.pref_key_ftp_server_data_port, R.string.pref_default_value_ftp_server_data_port
+        )
+
     val FTP_SERVER_HOME_DIRECTORY: SettingLiveData<Path> =
         ParcelValueSettingLiveData(
             R.string.pref_key_ftp_server_home_directory,

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -581,6 +581,8 @@
     <string name="ftp_server_username_title">用户名</string>
     <string name="ftp_server_password_title">密码</string>
     <string name="ftp_server_port_title">端口</string>
+    <string name="ftp_server_custom_data_port_title">自定义被动模式数据端口范围</string>
+    <string name="ftp_server_data_port_title">数据端口范围</string>
     <string name="ftp_server_home_directory_title">根文件夹</string>
     <string name="ftp_server_writable_title">允许写入</string>
 

--- a/app/src/main/res/values/donottranslate_prefs.xml
+++ b/app/src/main/res/values/donottranslate_prefs.xml
@@ -29,6 +29,10 @@
     <string name="pref_key_ftp_server_password">key_ftp_server_password</string>
     <string name="pref_key_ftp_server_port">key_ftp_server_port</string>
     <integer name="pref_default_value_ftp_server_port">2121</integer>
+    <string name="pref_key_ftp_server_custom_data_port">key_ftp_server_custom_data_port</string>
+    <bool name="pref_default_value_ftp_server_custom_data_port">false</bool>
+    <string name="pref_key_ftp_server_data_port">key_ftp_server_data_port</string>
+    <string name="pref_default_value_ftp_server_data_port">1024-65535</string>
     <string name="pref_key_ftp_server_home_directory">key_ftp_server_home_directory</string>
     <string name="pref_key_ftp_server_writable">key_ftp_server_writable</string>
     <bool name="pref_default_value_ftp_server_writable">true</bool>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -727,6 +727,8 @@
     <string name="ftp_server_username_title">Username</string>
     <string name="ftp_server_password_title">Password</string>
     <string name="ftp_server_port_title">Port</string>
+    <string name="ftp_server_custom_data_port_title">Using custom passive data ports</string>
+    <string name="ftp_server_data_port_title">Data Port Range</string>
     <string name="ftp_server_home_directory_title">Root folder</string>
     <string name="ftp_server_writable_title">Allow writing</string>
     <string name="ftp_server_notification_title" translatable="false">@string/ftp_server_title</string>

--- a/app/src/main/res/xml/ftp_server.xml
+++ b/app/src/main/res/xml/ftp_server.xml
@@ -5,7 +5,7 @@
   ~ All Rights Reserved.
   -->
 
-<PreferenceScreen
+<androidx.preference.PreferenceScreen
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
@@ -51,6 +51,18 @@
             android:defaultValue="@integer/pref_default_value_ftp_server_port"
             app:useSimpleSummaryProvider="true" />
 
+        <SwitchPreferenceCompat
+            android:key="@string/pref_key_ftp_server_custom_data_port"
+            android:title="@string/ftp_server_custom_data_port_title"
+            android:defaultValue="@bool/pref_default_value_ftp_server_custom_data_port" />
+
+        <me.zhanghai.android.files.settings.DefaultIfEmptyEditTextPreference
+            android:key="@string/pref_key_ftp_server_data_port"
+            android:title="@string/ftp_server_data_port_title"
+            android:defaultValue="@string/pref_default_value_ftp_server_data_port"
+            android:dependency="@string/pref_key_ftp_server_custom_data_port"
+            app:useSimpleSummaryProvider="true" />
+
         <me.zhanghai.android.files.ftpserver.FtpServerHomeDirectoryPreference
             android:key="@string/pref_key_ftp_server_home_directory"
             android:title="@string/ftp_server_home_directory_title"
@@ -61,4 +73,4 @@
             android:title="@string/ftp_server_writable_title"
             android:defaultValue="@bool/pref_default_value_ftp_server_writable" />
     </PreferenceCategory>
-</PreferenceScreen>
+</androidx.preference.PreferenceScreen>


### PR DESCRIPTION
The ftp server now does not support set data port range in passive mode so that there is no way to share my ftp server on Android through `frp`. But if we could set small range that passive ftp server could use to transfer data, then I could proxy all the ports through `frp`, then everything works!

Everything I have tested, working fine!

Please consider add this feature if you like or maybe you would accept this pr. Thanks!