### PR TITLE
Fix: keyboard hides EditText in dialogs

### DIFF
--- a/app/src/main/java/me/zhanghai/android/files/filelist/NameDialogFragment.kt
+++ b/app/src/main/java/me/zhanghai/android/files/filelist/NameDialogFragment.kt
@@ -50,7 +50,7 @@ abstract class NameDialogFragment : AppCompatDialogFragment() {
             .setNegativeButton(android.R.string.cancel, null)
             .create()
             .apply {
-                window!!.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_VISIBLE)
+                window!!.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_PAN)
                 // Override the listener here so that we have control over when to close the dialog.
                 setOnShowListener {
                     getButton(AlertDialog.BUTTON_POSITIVE).setOnClickListener { onOk() }

--- a/app/src/main/java/me/zhanghai/android/files/navigation/EditBookmarkDirectoryDialogFragment.kt
+++ b/app/src/main/java/me/zhanghai/android/files/navigation/EditBookmarkDirectoryDialogFragment.kt
@@ -64,7 +64,7 @@ class EditBookmarkDirectoryDialogFragment : AppCompatDialogFragment() {
             .setNeutralButton(R.string.remove) { _, _ -> remove() }
             .create()
             .apply {
-                window!!.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_VISIBLE)
+                window!!.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_PAN)
             }
 
     override fun onSaveInstanceState(outState: Bundle) {

--- a/app/src/main/java/me/zhanghai/android/files/storage/EditDeviceStorageDialogFragment.kt
+++ b/app/src/main/java/me/zhanghai/android/files/storage/EditDeviceStorageDialogFragment.kt
@@ -49,7 +49,7 @@ class EditDeviceStorageDialogFragment : AppCompatDialogFragment() {
             ) { _, _ -> toggleVisibility() }
             .create()
             .apply {
-                window!!.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_VISIBLE)
+                window!!.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_PAN)
             }
     }
 

--- a/app/src/main/java/me/zhanghai/android/files/storage/EditDocumentTreeDialogFragment.kt
+++ b/app/src/main/java/me/zhanghai/android/files/storage/EditDocumentTreeDialogFragment.kt
@@ -51,7 +51,7 @@ class EditDocumentTreeDialogFragment : AppCompatDialogFragment() {
             .setNeutralButton(R.string.remove) { _, _ -> remove() }
             .create()
             .apply {
-                window!!.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_VISIBLE)
+                window!!.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_PAN)
             }
 
     private fun save() {

--- a/app/src/main/java/me/zhanghai/android/files/storage/EditExternalStorageShortcutDialogFragment.kt
+++ b/app/src/main/java/me/zhanghai/android/files/storage/EditExternalStorageShortcutDialogFragment.kt
@@ -57,7 +57,7 @@ class EditExternalStorageShortcutDialogFragment : AppCompatDialogFragment() {
             .setNeutralButton(R.string.remove) { _, _ -> remove() }
             .create()
             .apply {
-                window!!.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_VISIBLE)
+                window!!.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_PAN)
                 // Override the listener here so that we have control over when to close the dialog.
                 setOnShowListener {
                     getButton(AlertDialog.BUTTON_POSITIVE).setOnClickListener { save() }


### PR DESCRIPTION
On some small screens the dialogs are being collapsed by the keyboard so you can't see what you're typing.

Before:

![Screenshot_20240608_143030](https://github.com/zhanghai/MaterialFiles/assets/12379835/c2181b4d-e56b-4c78-902d-376e1a0f8be2)

After:

![Screenshot_20240608_143312](https://github.com/zhanghai/MaterialFiles/assets/12379835/5d82a937-1ef6-45fd-9f36-6c37fc931ee4)


I'm aware of the copyright restrictions of this project. As this is a very small fix, feel free to make the changes by yourself
