### PR TITLE
feat: add option for denser layout of FileList

### DIFF
--- a/app/src/main/java/me/zhanghai/android/files/filelist/FileListAdapter.kt
+++ b/app/src/main/java/me/zhanghai/android/files/filelist/FileListAdapter.kt
@@ -87,6 +87,13 @@ class FileListAdapter(
             notifyItemRangeChanged(0, itemCount, PAYLOAD_STATE_CHANGED)
         }
 
+    private var _denseLayout: Boolean = false
+    var denseLayout: Boolean
+        get() = _denseLayout
+        set(value) {
+            _denseLayout = value
+        }
+
     fun replaceSelectedFiles(files: FileItemSet) {
         val changedFiles = fileItemSetOf()
         val iterator = selectedFiles.iterator()
@@ -190,6 +197,11 @@ class FileListAdapter(
                     CheckableItemBackground.create(4f, 12f, context)
                 } else {
                     CheckableItemBackground.create(0f, 0f, context)
+                }
+                if (viewType == FileViewType.LIST && denseLayout) {
+                    layoutParams = layoutParams.apply {
+                        height = context.resources.getDimensionPixelSize(R.dimen.dense_two_line_list_item_height)
+                    }
                 }
             }
             thumbnailOutlineView?.apply {

--- a/app/src/main/java/me/zhanghai/android/files/filelist/FileListFragment.kt
+++ b/app/src/main/java/me/zhanghai/android/files/filelist/FileListFragment.kt
@@ -362,6 +362,7 @@ class FileListFragment : Fragment(), BreadcrumbLayout.Listener, FileListAdapter.
         }
         viewModel.pickOptionsLiveData.observe(viewLifecycleOwner) { onPickOptionsChanged(it) }
         viewModel.selectedFilesLiveData.observe(viewLifecycleOwner) { onSelectedFilesChanged(it) }
+        Settings.FILE_LIST_DENSE_LAYOUT.observe(viewLifecycleOwner) { onDenseLayoutChanged(it) }
         viewModel.pasteStateLiveData.observe(viewLifecycleOwner) { onPasteStateChanged(it) }
         Settings.FILE_NAME_ELLIPSIZE.observe(viewLifecycleOwner) { onFileNameEllipsizeChanged(it) }
         viewModel.fileListLiveData.observe(viewLifecycleOwner) { onFileListChanged(it) }
@@ -663,7 +664,7 @@ class FileListFragment : Fragment(), BreadcrumbLayout.Listener, FileListAdapter.
                     persistentDrawerLayout.isDrawerOpen(GravityCompat.START)) {
                     widthDp -= getDimensionDp(R.dimen.navigation_max_width).roundToInt()
                 }
-                (widthDp / 180).coerceAtLeast(2)
+                (widthDp / 180).coerceAtLeast(if (adapter.denseLayout) 3 else 2 )
             }
         }
     }
@@ -844,6 +845,15 @@ class FileListFragment : Fragment(), BreadcrumbLayout.Listener, FileListAdapter.
     private fun onSelectedFilesChanged(files: FileItemSet) {
         updateOverlayToolbar()
         adapter.replaceSelectedFiles(files)
+    }
+
+    private fun onDenseLayoutChanged(denseLayout: Boolean) {
+        adapter.denseLayout = denseLayout
+        updateSpanCount()
+        // re-set adapter to prevent RecyclerView from recycling views and reusing old padding
+        // values on refresh. Neither notifyDataSetChanged() / notifyItemRangeChanged
+        // nor adapter.refresh() does work here.
+        binding.recyclerView.adapter = adapter
     }
 
     private fun updateOverlayToolbar() {

--- a/app/src/main/java/me/zhanghai/android/files/settings/Settings.kt
+++ b/app/src/main/java/me/zhanghai/android/files/settings/Settings.kt
@@ -126,6 +126,11 @@ object Settings {
             R.string.pref_key_file_list_animation, R.bool.pref_default_value_file_list_animation
         )
 
+    val FILE_LIST_DENSE_LAYOUT: SettingLiveData<Boolean> =
+        BooleanSettingLiveData(
+            R.string.pref_key_file_list_dense_layout, R.bool.pref_default_value_file_list_dense_layout
+        )
+
     val FILE_NAME_ELLIPSIZE: SettingLiveData<TextUtils.TruncateAt> =
         EnumSettingLiveData(
             R.string.pref_key_file_name_ellipsize, R.string.pref_default_value_file_name_ellipsize,

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -33,6 +33,7 @@
     <dimen name="dense_single_line_list_item_height">40dp</dimen>
     <dimen name="single_line_list_item_height">56dp</dimen>
     <dimen name="two_line_list_item_height">72dp</dimen>
+    <dimen name="dense_two_line_list_item_height">48dp</dimen>
     <dimen name="list_item_vertical_padding">16dp</dimen>
     <dimen name="horizontal_divider_height">1dp</dimen>
     <dimen name="small_icon_size">18dp</dimen>

--- a/app/src/main/res/values/donottranslate_prefs.xml
+++ b/app/src/main/res/values/donottranslate_prefs.xml
@@ -51,6 +51,8 @@
     <bool name="pref_default_value_black_night_mode">false</bool>
     <string name="pref_key_file_list_animation">key_file_list_animation</string>
     <bool name="pref_default_value_file_list_animation">true</bool>
+    <string name="pref_key_file_list_dense_layout">key_file_list_dense_layout</string>
+    <bool name="pref_default_value_file_list_dense_layout">false</bool>
     <string name="pref_key_file_name_ellipsize">key_file_name_ellipsize</string>
     <string name="pref_default_value_file_name_ellipsize">1</string>
     <string-array name="pref_entry_values_file_name_ellipsize">

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -748,6 +748,7 @@
     </string-array>
     <string name="settings_black_night_mode">Black night mode</string>
     <string name="settings_file_list_animation_title">File list animation</string>
+    <string name="settings_file_list_dense_layout_title">File list dense layout</string>
     <string name="settings_file_name_ellipsize_title">Display long file name</string>
     <string-array name="settings_file_name_ellipsize_entries">
         <item>Ellipsize the beginning</item>

--- a/app/src/main/res/xml/settings.xml
+++ b/app/src/main/res/xml/settings.xml
@@ -46,6 +46,11 @@
             android:title="@string/settings_file_list_animation_title"
             android:defaultValue="@bool/pref_default_value_file_list_animation" />
 
+        <SwitchPreferenceCompat
+            android:key="@string/pref_key_file_list_dense_layout"
+            android:title="@string/settings_file_list_dense_layout_title"
+            android:defaultValue="@bool/pref_default_value_file_list_dense_layout" />
+
         <rikka.preference.SimpleMenuPreference
             android:key="@string/pref_key_file_name_ellipsize"
             android:title="@string/settings_file_name_ellipsize_title"


### PR DESCRIPTION
This PR is a simple attempt to address #745 and introduce an option for a bit more dense layout. It is a very simple solution for now with just a quick toggle in the settings for a "more dense layout" which shrinks the height of the list elements to 48 dp.

In grid view, I increased the column count to 3 (instead of 2). More than 3 is not optimal since due to the badges and the overflow button, the width of the TextView gets very small and one might think about changing the item appearance in grid view entirely.

I know that as stated in the PR template, maybe this PR won't get accepted but since this is a quite simple implementation feel free to make the changes yourself since I think this is a long requested feature and many people would benefit from this basic implementation already.

Screenshots:

<img src="https://github.com/zhanghai/MaterialFiles/assets/28269133/99011e27-74ab-40af-a16e-6bdffbb979c9" width="300"> <img src="https://github.com/zhanghai/MaterialFiles/assets/28269133/4b7a6b17-2714-4a75-a99a-079643fb98d5" width="300">

<img src="https://github.com/zhanghai/MaterialFiles/assets/28269133/e158cffe-dea2-418f-a22f-cf9c68c20797" width="300"> <img src="https://github.com/zhanghai/MaterialFiles/assets/28269133/1ef6f959-d380-4c41-a0ab-02655922f8e1" width="300">