### PR TITLE
Feat: enable encryption support for SMB

### DIFF
--- a/app/src/main/java/me/zhanghai/android/files/provider/smb/client/Client.kt
+++ b/app/src/main/java/me/zhanghai/android/files/provider/smb/client/Client.kt
@@ -22,6 +22,7 @@ import com.hierynomus.mssmb2.messages.SMB2ChangeNotifyResponse
 import com.hierynomus.protocol.commons.EnumWithValue
 import com.hierynomus.smbj.ProgressListener
 import com.hierynomus.smbj.SMBClient
+import com.hierynomus.smbj.SmbConfig
 import com.hierynomus.smbj.auth.AuthenticationContext
 import com.hierynomus.smbj.common.SMBRuntimeException
 import com.hierynomus.smbj.session.Session
@@ -53,7 +54,8 @@ object Client {
     @Volatile
     lateinit var authenticator: Authenticator
 
-    private val client = SMBClient()
+    private val config = SmbConfig.builder().withEncryptData(true).build()
+    private val client = SMBClient(config)
 
     private val sessions = mutableMapOf<Authority, Session>()
 


### PR DESCRIPTION
*(Before we go on, yes I've read your PR template, yes I'm aware that you don't accept contributions 1:1. The PR is trivial however, consider this to be in the public domain.
Mostly just want to get the ball rolling into the right direction)*

I have a few shares on the same samba host (linux box) that has for some of those shares enforced encryption
```
[home]
smb encrypt = required
# ... more stuff

[media]
smb encrypt = desired
# more stuff
```

The smb library you are using by default doesn't negotiate encryption support, if you connect to the host, leading to EPERM when the home share gets accessed as an example, while the media share is still accessible.

In order that the encryption support is actually enabled by the lib, you need to do so with the config builder.
Not sure if you want to unconditionally do so or if this needs to be some sort of frontend setting, but as you anyway want to do the coding on your own I didn't bother trying to do so.
