### PR TITLE
fix: notification permission dialog references the wrong string

### DIFF
--- a/app/src/main/java/me/zhanghai/android/files/filelist/ShowRequestNotificationPermissionInSettingsRationaleDialogFragment.kt
+++ b/app/src/main/java/me/zhanghai/android/files/filelist/ShowRequestNotificationPermissionInSettingsRationaleDialogFragment.kt
@@ -20,7 +20,7 @@ class ShowRequestNotificationPermissionInSettingsRationaleDialogFragment : AppCo
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         return MaterialAlertDialogBuilder(requireContext(), theme)
-            .setMessage(R.string.notification_permission_rationale_message)
+            .setMessage(R.string.notification_permission_permanently_denied_message)
             .setPositiveButton(R.string.open_settings) { _, _ ->
                 listener.onShowRequestNotificationPermissionInSettingsRationaleResult(true)
             }


### PR DESCRIPTION
I understand that, as mentioned in the PR template, the PR may not be accepted, but I just hope you can notice this small mistake and correct it, or of course, you can just click the button to merge this simple change.