### PR TITLE
Support Shizuku alongside Sui

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -186,6 +186,7 @@ dependencies {
     implementation 'dev.chrisbanes:insetter-ktx:0.3.1'
     implementation 'dev.rikka.rikkax.preference:simplemenu-preference:1.0.3'
     implementation 'dev.rikka.shizuku:api:13.1.5'
+    implementation 'dev.rikka.shizuku:provider:13.1.5'
     implementation ('eu.agno3.jcifs:jcifs-ng:2.1.10') {
         exclude group: 'org.bouncycastle', module: 'bcprov-jdk18on'
     }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -33,7 +33,7 @@
     <uses-permission android:name="com.android.launcher.permission.INSTALL_SHORTCUT" />
 
     <!-- Shizuku requires API 23. -->
-    <uses-sdk tools:overrideLibrary="rikka.shizuku.aidl,rikka.shizuku.api,rikka.shizuku.shared" />
+    <uses-sdk tools:overrideLibrary="rikka.shizuku.aidl,rikka.shizuku.api,rikka.shizuku.shared,rikka.shizuku.provider" />
 
     <!--
       ~ Samsung DeX requires explicitly setting android:resizeableActivity="true" for the app to be
@@ -388,6 +388,14 @@
             android:authorities="@string/file_provider_authority"
             android:exported="false"
             android:grantUriPermissions="true" />
+
+	<provider
+            android:name="rikka.shizuku.ShizukuProvider"
+            android:authorities="${applicationId}.shizuku"
+            android:multiprocess="false"
+            android:enabled="true"
+            android:exported="true"
+            android:permission="android.permission.INTERACT_ACROSS_USERS_FULL" />
 
         <receiver android:name="me.zhanghai.android.files.filejob.FileJobReceiver" />
 

--- a/app/src/main/java/me/zhanghai/android/files/provider/root/RootFileService.kt
+++ b/app/src/main/java/me/zhanghai/android/files/provider/root/RootFileService.kt
@@ -22,8 +22,8 @@ lateinit var rootContext: Context private set
 
 object RootFileService : RemoteFileService(
     RemoteInterface {
-        if (SuiFileServiceLauncher.isSuiAvailable()) {
-            SuiFileServiceLauncher.launchService()
+        if (ShizukuFileServiceLauncher.isShizukuAvailable()) {
+            ShizukuFileServiceLauncher.launchService()
         } else {
             LibSuFileServiceLauncher.launchService()
         }


### PR DESCRIPTION
Not a large change, but both Sui and Shizuku use the Shizuku-Api.

Currently Material Files only supports Sui.
Shizuku seems to be more maintained than sui. Shizuku supports root as well as rootless (Sui only with root).

This pr adds a small change, that allows Shizuku to be used as well.
