### PR TITLE
Add SEND_MULTIPLE support for saving multiple files

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -310,6 +310,7 @@
             </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.SEND" />
+                <action android:name="android.intent.action.SEND_MULTIPLE" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <data android:mimeType="*/*" />
             </intent-filter>

--- a/app/src/main/java/me/zhanghai/android/files/util/IntentPathExtensions.kt
+++ b/app/src/main/java/me/zhanghai/android/files/util/IntentPathExtensions.kt
@@ -48,6 +48,19 @@ val Intent.saveAsPath: Path?
         return uri?.toPathOrNull()
     }
 
+val Intent.saveAsPaths: List<Path>
+    get() =
+        when (action) {
+            Intent.ACTION_VIEW -> listOfNotNull(data?.toPathOrNull())
+            Intent.ACTION_SEND ->
+                listOfNotNull((getParcelableExtraSafe(Intent.EXTRA_STREAM) as? Uri)?.toPathOrNull())
+            Intent.ACTION_SEND_MULTIPLE ->
+                getParcelableArrayListExtraSafe<Uri>(Intent.EXTRA_STREAM)
+                    ?.mapNotNull { it.toPathOrNull() }
+                    ?: emptyList()
+            else -> emptyList()
+        }
+
 private fun Uri.toPathOrNull(): Path? =
     when (scheme) {
         ContentResolver.SCHEME_FILE, null -> path?.takeIfNotEmpty()?.let { Paths.get(it) }

--- a/app/src/main/java/me/zhanghai/android/files/viewer/saveas/SaveAsActivity.kt
+++ b/app/src/main/java/me/zhanghai/android/files/viewer/saveas/SaveAsActivity.kt
@@ -15,30 +15,37 @@ import me.zhanghai.android.files.file.MimeType
 import me.zhanghai.android.files.file.asMimeTypeOrNull
 import me.zhanghai.android.files.filejob.FileJobService
 import me.zhanghai.android.files.filelist.FileListActivity
-import me.zhanghai.android.files.util.saveAsPath
+import me.zhanghai.android.files.util.saveAsPaths
 import me.zhanghai.android.files.util.showToast
 
 class SaveAsActivity : AppActivity() {
     private val createFileLauncher =
         registerForActivityResult(FileListActivity.CreateFileContract(), ::onCreateFileResult)
 
+    private val openDirectoryLauncher =
+        registerForActivityResult(FileListActivity.OpenDirectoryContract(), ::onOpenDirectoryResult)
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
         val intent = intent
-        val mimeType = intent.type?.asMimeTypeOrNull() ?: MimeType.ANY
-        val path = intent.saveAsPath
-        if (path == null) {
+        val paths = intent.saveAsPaths
+        if (paths.isEmpty()) {
             showToast(R.string.save_as_error)
             finish()
             return
         }
-        val title = path.fileName.toString()
         val initialPath =
             Paths.get(
                 Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS).path
             )
-        createFileLauncher.launch(Triple(mimeType, title, initialPath))
+        if (paths.size == 1) {
+            val mimeType = intent.type?.asMimeTypeOrNull() ?: MimeType.ANY
+            val title = paths.first().fileName.toString()
+            createFileLauncher.launch(Triple(mimeType, title, initialPath))
+        } else {
+            openDirectoryLauncher.launch(initialPath)
+        }
     }
 
     private fun onCreateFileResult(result: Path?) {
@@ -46,7 +53,16 @@ class SaveAsActivity : AppActivity() {
             finish()
             return
         }
-        FileJobService.save(intent.saveAsPath!!, result, this)
+        FileJobService.save(intent.saveAsPaths.first(), result, this)
+        finish()
+    }
+
+    private fun onOpenDirectoryResult(result: Path?) {
+        if (result == null) {
+            finish()
+            return
+        }
+        FileJobService.copy(intent.saveAsPaths, result, this)
         finish()
     }
 }


### PR DESCRIPTION
Adds support for saving multiple files via SEND_MULTIPLE intent

Single file: shows file creation dialog (existing behavior)
Multiple files: shows directory picker, then copies all files to selected directory