### PR TITLE
Raw 'UnsupportedOperationException' toast displayed when attempting to create file in .jar file

### DIFF
--- a/app/src/main/java/me/zhanghai/android/files/filelist/FileListFragment.kt
+++ b/app/src/main/java/me/zhanghai/android/files/filelist/FileListFragment.kt
@@ -250,6 +250,11 @@ class FileListFragment : Fragment(), BreadcrumbLayout.Listener, FileListAdapter.
         )
         binding.speedDialView.inflate(R.menu.file_list_speed_dial)
         binding.speedDialView.setOnActionSelectedListener {
+            if(viewModel.currentPath.isArchivePath){
+                showToast("Cannot write to read-only archive")
+                binding.speedDialView.close()
+                return@setOnActionSelectedListener false
+            }
             when (it.id) {
                 R.id.action_create_file -> showCreateFileDialog()
                 R.id.action_create_directory -> showCreateDirectoryDialog()


### PR DESCRIPTION
fix: #1511 

### Problem
Currently, when attempting to create a file inside a JAR or other archive, the app displays a raw `java.lang.UnsupportedOperationException` toast, which is confusing to users (#1511).

### Solution
- Show a user-friendly toast: "Unable to create a file inside archive"