### PR TITLE
Fix/1510 clear search does not refresh list

### DIFF
--- a/app/src/main/java/me/zhanghai/android/files/filelist/FileListFragment.kt
+++ b/app/src/main/java/me/zhanghai/android/files/filelist/FileListFragment.kt
@@ -425,8 +425,12 @@ class FileListFragment : Fragment(), BreadcrumbLayout.Listener, FileListAdapter.
                     return false
                 }
                 viewModel.searchViewQuery = query
-                debouncedSearchRunnable()
-                return false
+                if (query.isBlank()) {
+                    viewModel.stopSearching()
+                } else {
+                    debouncedSearchRunnable()
+                }
+                return true
             }
         })
         if (viewModel.isSearchViewExpanded) {


### PR DESCRIPTION
fix #1510 

Description :- Issue is when search bar is blank then it does not return the list of files or folders.

Fixup:- maintained a check on onQueryTextChange if search bar is blank then return the list of files or folders.

