### PR TITLE
Clearing search text does not refresh the file list

### DIFF
--- a/app/src/main/java/me/zhanghai/android/files/filelist/FileListFragment.kt
+++ b/app/src/main/java/me/zhanghai/android/files/filelist/FileListFragment.kt
@@ -420,8 +420,12 @@ class FileListFragment : Fragment(), BreadcrumbLayout.Listener, FileListAdapter.
                     return false
                 }
                 viewModel.searchViewQuery = query
-                debouncedSearchRunnable()
-                return false
+                if (query.isBlank()) {
+                    viewModel.stopSearching()
+                } else {
+                    debouncedSearchRunnable()
+                }
+                return true
             }
         })
         if (viewModel.isSearchViewExpanded) {


### PR DESCRIPTION
fix: #1516 

Description:- Issue is when search bar is blank it does not show any files.

Fixup:- Maintained a check on onQueryTextChange when search bar is blank return the list