### PR TITLE
WebDAV: Trailing slash for DELETE and MOVE on dirs

### DIFF
--- a/app/src/main/java/me/zhanghai/android/files/filejob/FileJobs.kt
+++ b/app/src/main/java/me/zhanghai/android/files/filejob/FileJobs.kt
@@ -964,7 +964,7 @@ class DeleteFileJob(private val paths: List<Path>) : FileJob() {
         Files.walkFileTree(path, object : SimpleFileVisitor<Path>() {
             @Throws(IOException::class)
             override fun visitFile(file: Path, attributes: BasicFileAttributes): FileVisitResult {
-                delete(file, transferInfo, actionAllInfo)
+                delete(file, attributes.isDirectory, transferInfo, actionAllInfo)
                 throwIfInterrupted()
                 return FileVisitResult.CONTINUE
             }
@@ -984,7 +984,7 @@ class DeleteFileJob(private val paths: List<Path>) : FileJob() {
                 if (exception != null) {
                     throw exception
                 }
-                delete(directory, transferInfo, actionAllInfo)
+                delete(directory, true, transferInfo, actionAllInfo)
                 throwIfInterrupted()
                 return FileVisitResult.CONTINUE
             }
@@ -993,12 +993,17 @@ class DeleteFileJob(private val paths: List<Path>) : FileJob() {
 }
 
 @Throws(IOException::class)
-private fun FileJob.delete(path: Path, transferInfo: TransferInfo?, actionAllInfo: ActionAllInfo) {
+private fun FileJob.delete(
+    path: Path,
+    isDirectory: Boolean?,
+    transferInfo: TransferInfo?,
+    actionAllInfo: ActionAllInfo
+) {
     var retry: Boolean
     do {
         retry = false
         try {
-            path.delete()
+            path.delete(isDirectory)
             if (transferInfo != null) {
                 transferInfo.incrementTransferredFileCount()
                 postDeleteNotification(transferInfo, path)
@@ -1152,7 +1157,7 @@ class MoveFileJob(private val sources: List<Path>, private val targetDirectory: 
                 if (exception != null) {
                     throw exception
                 }
-                delete(directory, null, actionAllInfo)
+                delete(directory, true, null, actionAllInfo)
                 throwIfInterrupted()
                 return FileVisitResult.CONTINUE
             }

--- a/app/src/main/java/me/zhanghai/android/files/ftpserver/ProviderFtpFile.kt
+++ b/app/src/main/java/me/zhanghai/android/files/ftpserver/ProviderFtpFile.kt
@@ -151,7 +151,7 @@ class ProviderFtpFile(
             false
         } else {
             try {
-                path.delete()
+                path.delete(null)
                 true
             } catch (e: IOException) {
                 e.printStackTrace()

--- a/app/src/main/java/me/zhanghai/android/files/provider/common/ForeignCopyMove.kt
+++ b/app/src/main/java/me/zhanghai/android/files/provider/common/ForeignCopyMove.kt
@@ -142,11 +142,11 @@ internal object ForeignCopyMove {
         }
         copy(source, target, *optionsForCopy)
         try {
-            source.delete()
+            source.delete(null)
         } catch (e: IOException) {
             if (e !is NoSuchFileException) {
                 try {
-                    target.delete()
+                    target.delete(null)
                 } catch (e2: IOException) {
                     e.addSuppressed(e2)
                 } catch (e2: UnsupportedOperationException) {
@@ -156,7 +156,7 @@ internal object ForeignCopyMove {
             throw e
         } catch (e: UnsupportedOperationException) {
             try {
-                target.delete()
+                target.delete(null)
             } catch (e2: IOException) {
                 e.addSuppressed(e2)
             } catch (e2: UnsupportedOperationException) {

--- a/app/src/main/java/me/zhanghai/android/files/provider/common/PathExtensions.kt
+++ b/app/src/main/java/me/zhanghai/android/files/provider/common/PathExtensions.kt
@@ -5,6 +5,8 @@
 
 package me.zhanghai.android.files.provider.common
 
+import me.zhanghai.android.files.provider.webdav.WebDavFileSystemProvider
+import me.zhanghai.android.files.provider.webdav.WebDavPath
 import java8.nio.channels.SeekableByteChannel
 import java8.nio.file.AccessMode
 import java8.nio.file.CopyOption
@@ -81,8 +83,12 @@ fun Path.createSymbolicLink(target: ByteString, vararg attributes: FileAttribute
     createSymbolicLink(ByteStringPath(target), *attributes)
 
 @Throws(IOException::class)
-fun Path.delete() {
-    Files.delete(this)
+fun Path.delete(isDirectory: Boolean?) {
+    if (provider == WebDavFileSystemProvider && this is WebDavPath) {
+        WebDavFileSystemProvider.delete(this, isDirectory)
+    } else {
+        Files.delete(this)
+    }
 }
 
 @Throws(IOException::class)

--- a/app/src/main/java/me/zhanghai/android/files/provider/webdav/WebDavCopyMove.kt
+++ b/app/src/main/java/me/zhanghai/android/files/provider/webdav/WebDavCopyMove.kt
@@ -44,7 +44,7 @@ internal object WebDavCopyMove {
                 throw FileAlreadyExistsException(source.toString(), target.toString(), null)
             }
             try {
-                Client.delete(target)
+                Client.delete(target, targetFile.isDirectory)
             } catch (e: DavException) {
                 throw e.toFileSystemException(target.toString())
             }
@@ -139,14 +139,14 @@ internal object WebDavCopyMove {
                 throw FileAlreadyExistsException(source.toString(), target.toString(), null)
             }
             try {
-                Client.delete(target)
+                Client.delete(target, targetResponse.isDirectory)
             } catch (e: DavException) {
                 throw e.toFileSystemException(target.toString())
             }
         }
         var renameSuccessful = false
         try {
-            Client.move(source, target)
+            Client.move(source, target, sourceResponse.isDirectory)
             renameSuccessful = true
         } catch (e: DavException) {
             if (copyOptions.atomicMove) {
@@ -170,11 +170,11 @@ internal object WebDavCopyMove {
         }
         copy(source, target, copyOptions)
         try {
-            Client.delete(source)
+            Client.delete(source, sourceResponse.isDirectory)
         } catch (e: DavException) {
             if (e.toFileSystemException(source.toString()) !is NoSuchFileException) {
                 try {
-                    Client.delete(target)
+                    Client.delete(target, sourceResponse.isDirectory)
                 } catch (e2: DavException) {
                     e.addSuppressed(e2.toFileSystemException(target.toString()))
                 }

--- a/app/src/main/java/me/zhanghai/android/files/provider/webdav/WebDavFileSystemProvider.kt
+++ b/app/src/main/java/me/zhanghai/android/files/provider/webdav/WebDavFileSystemProvider.kt
@@ -46,6 +46,7 @@ import me.zhanghai.android.files.provider.common.toOpenOptions
 import me.zhanghai.android.files.provider.webdav.client.Authority
 import me.zhanghai.android.files.provider.webdav.client.Client
 import me.zhanghai.android.files.provider.webdav.client.Protocol
+import me.zhanghai.android.files.provider.webdav.client.isDirectory
 import me.zhanghai.android.files.provider.webdav.client.isSymbolicLink
 import java.io.IOException
 import java.io.InputStream
@@ -300,8 +301,13 @@ object WebDavFileSystemProvider : FileSystemProvider(), PathObservableProvider, 
     @Throws(IOException::class)
     override fun delete(path: Path) {
         path as? WebDavPath ?: throw ProviderMismatchException(path.toString())
+        val pathResponse = try {
+            Client.findProperties(path, true)
+        } catch (e: DavException) {
+            throw e.toFileSystemException(path.toString())
+        }
         try {
-            Client.delete(path)
+            Client.delete(path, pathResponse.isDirectory)
         } catch (e: DavException) {
             throw e.toFileSystemException(path.toString())
         }

--- a/app/src/main/java/me/zhanghai/android/files/provider/webdav/WebDavFileSystemProvider.kt
+++ b/app/src/main/java/me/zhanghai/android/files/provider/webdav/WebDavFileSystemProvider.kt
@@ -301,13 +301,22 @@ object WebDavFileSystemProvider : FileSystemProvider(), PathObservableProvider, 
     @Throws(IOException::class)
     override fun delete(path: Path) {
         path as? WebDavPath ?: throw ProviderMismatchException(path.toString())
-        val pathResponse = try {
-            Client.findProperties(path, true)
-        } catch (e: DavException) {
-            throw e.toFileSystemException(path.toString())
+        delete(path, null)
+    }
+
+    @Throws(IOException::class)
+    internal fun delete(path: WebDavPath, isDirectory: Boolean?) {
+        val resolvedIsDirectory = if (isDirectory != null) {
+            isDirectory
+        } else {
+            try {
+                Client.findProperties(path, true).isDirectory
+            } catch (e: DavException) {
+                throw e.toFileSystemException(path.toString())
+            }
         }
         try {
-            Client.delete(path, pathResponse.isDirectory)
+            Client.delete(path, resolvedIsDirectory)
         } catch (e: DavException) {
             throw e.toFileSystemException(path.toString())
         }

--- a/app/src/main/java/me/zhanghai/android/files/provider/webdav/WebDavPath.kt
+++ b/app/src/main/java/me/zhanghai/android/files/provider/webdav/WebDavPath.kt
@@ -101,6 +101,15 @@ internal class WebDavPath : ByteStringListPath<WebDavPath>, Client.Path {
             .addPathSegments(toString().removePrefix("/"))
             .build()
 
+    override val directoryUrl: HttpUrl
+        get() = if (toString() == "/") {
+            url
+        } else {
+            url.newBuilder()
+                .addPathSegment("")
+                .build()
+        }
+
     private constructor(source: Parcel) : super(source) {
         fileSystem = source.readParcelable()!!
     }

--- a/app/src/main/java/me/zhanghai/android/files/provider/webdav/client/Client.kt
+++ b/app/src/main/java/me/zhanghai/android/files/provider/webdav/client/Client.kt
@@ -99,9 +99,9 @@ object Client {
     }
 
     @Throws(DavException::class)
-    fun delete(path: Path) {
+    fun delete(path: Path, isDirectory: Boolean = false) {
         try {
-            DavResource(getClient(path.authority), path.url).delete {}
+            DavResource(getClient(path.authority), path.url(isDirectory)).delete {}
         } catch (e: IOException) {
             throw e.toDavException()
         }
@@ -110,12 +110,13 @@ object Client {
     }
 
     @Throws(DavException::class)
-    fun move(source: Path, target: Path) {
+    fun move(source: Path, target: Path, isDirectory: Boolean = false) {
         if (source.authority != target.authority) {
             throw IOException("Paths aren't on the same authority")
         }
         try {
-            DavResource(getClient(source.authority), source.url).move(target.url, false) {}
+            DavResource(getClient(source.authority), source.url(isDirectory))
+                .move(target.url(isDirectory), false) {}
         } catch (e: IOException) {
             throw e.toDavException()
         }
@@ -257,8 +258,16 @@ object Client {
     interface Path {
         val authority: Authority
         val url: HttpUrl
+        val directoryUrl: HttpUrl
         fun resolve(other: String): Path
     }
+
+    private fun Path.url(isDirectory: Boolean): HttpUrl =
+        if (isDirectory) {
+            directoryUrl
+        } else {
+            url
+        }
 
     private class OkHttpAuthenticatorInterceptor(
         private val authenticator: Authenticator,

--- a/app/src/main/java/me/zhanghai/android/files/viewer/image/ImageViewerFragment.kt
+++ b/app/src/main/java/me/zhanghai/android/files/viewer/image/ImageViewerFragment.kt
@@ -162,7 +162,8 @@ class ImageViewerFragment : Fragment(), ConfirmDeleteDialogFragment.Listener {
 
     override fun delete(path: Path) {
         try {
-            path.delete()
+            // The image viewer only deletes files, se we pass isDirectory=false
+            path.delete(false)
         } catch (e: IOException) {
             e.printStackTrace()
             showToast(e.toString())


### PR DESCRIPTION
According to WebDAV RFC when issuing a MOVE or DELETE on a folder (instead of a file), the path should have a trailing slash.

Fixes https://github.com/zhanghai/MaterialFiles/issues/1475

@zhanghai do you accept contributions?

I've tested it against the Nginx webdav server.

The only downside with this change I can see is that it adds one more PROPFIND when deleting files or folders. It guess it could be avoided, but would require quite some code changes, to pass along the information whether the path to be deleted is a file or a folder.