### PR TITLE
Fix TV D-pad navigation in multi-select action mode toolbar

### DIFF
--- a/app/src/main/java/me/zhanghai/android/files/filelist/FileListFragment.kt
+++ b/app/src/main/java/me/zhanghai/android/files/filelist/FileListFragment.kt
@@ -221,7 +221,7 @@ class FileListFragment : Fragment(), BreadcrumbLayout.Listener, FileListAdapter.
         val activity = requireActivity() as AppCompatActivity
         activity.setTitle(R.string.file_list_title)
         activity.setSupportActionBar(binding.toolbar)
-        overlayActionMode = OverlayToolbarActionMode(binding.overlayToolbar)
+        overlayActionMode = OverlayToolbarActionMode(binding.overlayToolbar, binding.toolbar)
         bottomActionMode = PersistentBarLayoutToolbarActionMode(
             binding.persistentBarLayout, binding.bottomBarLayout, binding.bottomToolbar
         )

--- a/app/src/main/java/me/zhanghai/android/files/ui/OverlayToolbarActionMode.kt
+++ b/app/src/main/java/me/zhanghai/android/files/ui/OverlayToolbarActionMode.kt
@@ -11,14 +11,21 @@ import androidx.core.view.isVisible
 import me.zhanghai.android.files.util.fadeInUnsafe
 import me.zhanghai.android.files.util.fadeOutUnsafe
 
-class OverlayToolbarActionMode(bar: ViewGroup, toolbar: Toolbar) : ToolbarActionMode(bar, toolbar) {
+class OverlayToolbarActionMode(
+    bar: ViewGroup,
+    toolbar: Toolbar,
+    private val siblingView: ViewGroup? = null
+) : ToolbarActionMode(bar, toolbar) {
     constructor(toolbar: Toolbar) : this(toolbar, toolbar)
+
+    constructor(toolbar: Toolbar, siblingView: ViewGroup) : this(toolbar, toolbar, siblingView)
 
     init {
         bar.isVisible = false
     }
 
     override fun show(bar: ViewGroup, animate: Boolean) {
+        siblingView?.descendantFocusability = ViewGroup.FOCUS_BLOCK_DESCENDANTS
         if (animate) {
             bar.fadeInUnsafe()
         } else {
@@ -27,6 +34,7 @@ class OverlayToolbarActionMode(bar: ViewGroup, toolbar: Toolbar) : ToolbarAction
     }
 
     override fun hide(bar: ViewGroup, animate: Boolean) {
+        siblingView?.descendantFocusability = ViewGroup.FOCUS_BEFORE_DESCENDANTS
         if (animate) {
             bar.fadeOutUnsafe()
         } else {


### PR DESCRIPTION
> 修复 TV 遥控器在多选模式工具栏中的方向键导航问题

## Problem / 问题描述

On TV devices, when using the D-pad to navigate the multi-select action
mode toolbar, pressing Right from `action_cut` does not move focus to
`action_copy`. Navigation between toolbar action buttons is broken.

> 在 TV 设备上使用遥控器操作多选模式工具栏时，从 `action_cut` 按右键后
> 焦点不会移动到 `action_copy`，工具栏按钮之间的方向键导航失效。

## Root Cause / 根本原因

`overlayToolbar` and the regular `toolbar` are stacked in the same
`FrameLayout`. When the overlay action mode is active, the regular
`toolbar` is only hidden visually (`isVisible = false`) but its child
views remain focusable. `FocusFinder` searches all focusable views by
geometry and finds the regular toolbar's menu buttons (search, sort,
etc.), which overlap with the overlay toolbar's buttons and interrupt
the focus chain.

> `overlayToolbar` 与常规 `toolbar` 叠放在同一 `FrameLayout` 中。覆盖层
> 激活时，常规 `toolbar` 仅在视觉上隐藏，但其子 View 仍处于可聚焦状态。
> `FocusFinder` 按几何位置搜索所有可聚焦 View，常规 `toolbar` 的菜单按钮
> （搜索、排序等）与覆盖层菜单项位置重叠，打断了焦点链路。

## Fix / 修复方案

Pass the regular `toolbar` as a `siblingView` to `OverlayToolbarActionMode`.
When the overlay is shown, set `siblingView.descendantFocusability` to
`FOCUS_BLOCK_DESCENDANTS` to exclude all its children from focus search.
Restore it to `FOCUS_BEFORE_DESCENDANTS` when the overlay is hidden.

> 将常规 `toolbar` 作为 `siblingView` 传入 `OverlayToolbarActionMode`。
> 覆盖层显示时，将 `siblingView.descendantFocusability` 设置为
> `FOCUS_BLOCK_DESCENDANTS`，阻止其所有子 View 参与焦点搜索；
> 覆盖层隐藏时恢复为 `FOCUS_BEFORE_DESCENDANTS`。


这个项目很不错，美观又好用，我装到 tv 设备上之后，只能用遥控器操作，发现往右选不到删除按钮，需要优化下。
我写后端的，前端不是很熟，这个 pr 可以不用 merge，希望作者可以帮忙改下发个版本十分感谢！