### PR TITLE
Selection: 'Strip metadata' action for image files

### DIFF
--- a/app/src/main/java/me/zhanghai/android/files/filejob/MetadataStripper.kt
+++ b/app/src/main/java/me/zhanghai/android/files/filejob/MetadataStripper.kt
@@ -1,0 +1,64 @@
+package me.zhanghai.android.files.filejob
+
+import androidx.exifinterface.media.ExifInterface
+import java.io.File
+
+object MetadataStripper {
+    private val TAGS_TO_STRIP = arrayOf(
+        ExifInterface.TAG_GPS_LATITUDE,
+        ExifInterface.TAG_GPS_LATITUDE_REF,
+        ExifInterface.TAG_GPS_LONGITUDE,
+        ExifInterface.TAG_GPS_LONGITUDE_REF,
+        ExifInterface.TAG_GPS_ALTITUDE,
+        ExifInterface.TAG_GPS_ALTITUDE_REF,
+        ExifInterface.TAG_GPS_TIMESTAMP,
+        ExifInterface.TAG_GPS_DATESTAMP,
+        ExifInterface.TAG_GPS_PROCESSING_METHOD,
+        ExifInterface.TAG_GPS_AREA_INFORMATION,
+        ExifInterface.TAG_GPS_DEST_BEARING,
+        ExifInterface.TAG_GPS_DEST_BEARING_REF,
+        ExifInterface.TAG_GPS_DEST_DISTANCE,
+        ExifInterface.TAG_GPS_DEST_DISTANCE_REF,
+        ExifInterface.TAG_GPS_DEST_LATITUDE,
+        ExifInterface.TAG_GPS_DEST_LATITUDE_REF,
+        ExifInterface.TAG_GPS_DEST_LONGITUDE,
+        ExifInterface.TAG_GPS_DEST_LONGITUDE_REF,
+        ExifInterface.TAG_GPS_IMG_DIRECTION,
+        ExifInterface.TAG_GPS_IMG_DIRECTION_REF,
+        ExifInterface.TAG_GPS_SPEED,
+        ExifInterface.TAG_GPS_SPEED_REF,
+        ExifInterface.TAG_GPS_TRACK,
+        ExifInterface.TAG_GPS_TRACK_REF,
+        ExifInterface.TAG_DATETIME,
+        ExifInterface.TAG_DATETIME_ORIGINAL,
+        ExifInterface.TAG_DATETIME_DIGITIZED,
+        ExifInterface.TAG_OFFSET_TIME,
+        ExifInterface.TAG_OFFSET_TIME_ORIGINAL,
+        ExifInterface.TAG_OFFSET_TIME_DIGITIZED,
+        ExifInterface.TAG_MAKE,
+        ExifInterface.TAG_MODEL,
+        ExifInterface.TAG_SOFTWARE,
+        ExifInterface.TAG_ARTIST,
+        ExifInterface.TAG_COPYRIGHT,
+        ExifInterface.TAG_USER_COMMENT,
+        ExifInterface.TAG_IMAGE_DESCRIPTION,
+        ExifInterface.TAG_SUBJECT_LOCATION,
+        ExifInterface.TAG_SUBJECT_AREA,
+        ExifInterface.TAG_BODY_SERIAL_NUMBER,
+        ExifInterface.TAG_LENS_SERIAL_NUMBER,
+        ExifInterface.TAG_CAMERA_OWNER_NAME,
+    )
+
+    fun stripFromFile(file: File): Boolean {
+        val exif = ExifInterface(file)
+        var changed = false
+        for (tag in TAGS_TO_STRIP) {
+            if (exif.getAttribute(tag) != null) {
+                exif.setAttribute(tag, null)
+                changed = true
+            }
+        }
+        if (changed) exif.saveAttributes()
+        return changed
+    }
+}

--- a/app/src/main/java/me/zhanghai/android/files/filelist/FileListFragment.kt
+++ b/app/src/main/java/me/zhanghai/android/files/filelist/FileListFragment.kt
@@ -45,12 +45,16 @@ import androidx.drawerlayout.widget.DrawerLayout
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.commit
 import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import com.leinardi.android.speeddial.SpeedDialView
 import java8.nio.file.Path
 import java8.nio.file.Paths
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import kotlinx.parcelize.Parcelize
 import me.zhanghai.android.files.R
 import me.zhanghai.android.files.app.application
@@ -71,6 +75,7 @@ import me.zhanghai.android.files.file.fileProviderUri
 import me.zhanghai.android.files.file.isApk
 import me.zhanghai.android.files.file.isImage
 import me.zhanghai.android.files.filejob.FileJobService
+import me.zhanghai.android.files.filejob.MetadataStripper
 import me.zhanghai.android.files.filelist.FileSortOptions.By
 import me.zhanghai.android.files.filelist.FileSortOptions.Order
 import me.zhanghai.android.files.fileproperties.FilePropertiesDialogFragment
@@ -947,12 +952,48 @@ class FileListFragment : Fragment(), BreadcrumbLayout.Listener, FileListAdapter.
                 shareFiles(viewModel.selectedFiles)
                 true
             }
+            R.id.action_strip_metadata -> {
+                stripMetadataFromFiles(viewModel.selectedFiles)
+                true
+            }
             R.id.action_select_all -> {
                 selectAllFiles()
                 true
             }
             else -> false
         }
+
+    private fun stripMetadataFromFiles(files: FileItemSet) {
+        val targets = files.filter { fileItem ->
+            fileItem.mimeType.isImage && fileItem.path.isLinuxPath
+        }
+        if (targets.isEmpty()) {
+            showToast(R.string.file_list_strip_metadata_none)
+            viewModel.selectFiles(files, false)
+            return
+        }
+        viewLifecycleOwner.lifecycleScope.launch {
+            val result = withContext(Dispatchers.IO) {
+                var stripped = 0
+                var unchanged = 0
+                var failed = 0
+                for (fileItem in targets) {
+                    runCatching {
+                        if (MetadataStripper.stripFromFile(fileItem.path.toFile())) stripped++
+                        else unchanged++
+                    }.onFailure { failed++ }
+                }
+                Triple(stripped, unchanged, failed)
+            }
+            showToast(
+                getString(
+                    R.string.file_list_strip_metadata_result_format,
+                    result.first, result.second, result.third
+                )
+            )
+            viewModel.selectFiles(files, false)
+        }
+    }
 
     private fun onOverlayActionModeFinished() {
         viewModel.clearSelectedFiles()

--- a/app/src/main/res/menu/file_list_select.xml
+++ b/app/src/main/res/menu/file_list_select.xml
@@ -53,6 +53,12 @@
         app:showAsAction="never" />
 
     <item
+        android:id="@+id/action_strip_metadata"
+        android:orderInCategory="100"
+        android:title="@string/file_list_select_action_strip_metadata"
+        app:showAsAction="never" />
+
+    <item
         android:id="@+id/action_select_all"
         android:alphabeticShortcut="a"
         android:orderInCategory="100"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -309,6 +309,9 @@
     <string name="file_list_select_title_format">%1$,d</string>
     <string name="file_list_select_action_extract" translatable="false">@string/file_item_action_extract</string>
     <string name="file_list_select_action_archive" translatable="false">@string/file_item_action_archive</string>
+    <string name="file_list_select_action_strip_metadata">Strip metadata</string>
+    <string name="file_list_strip_metadata_none">No image files selected</string>
+    <string name="file_list_strip_metadata_result_format">Stripped %1$,d, unchanged %2$,d, failed %3$,d</string>
     <string name="file_list_create_file_name_hint">File name</string>
     <string name="file_list_create_file_name_error_empty" translatable="false">@string/file_name_error_empty</string>
     <string name="file_list_create_file_name_error_invalid" translatable="false">@string/file_name_error_invalid</string>


### PR DESCRIPTION
## Problem

Modern cameras embed location, timestamp, device make/model/serial, and software signature in EXIF. When a user copies a photo to a USB drive, attaches it to an email from a different app, or uploads it to a service that doesn't strip metadata server-side, all of that data travels with the file. MaterialFiles is often the last touch point before that copy/upload, which makes it a natural place to offer the strip.

## Fix

Adds **"Strip metadata"** to the selection action menu. When invoked:

1. Filter the selection to image files on a real Linux path (skips documents, archives, `content://` URIs, etc.).
2. For each image, open `androidx.exifinterface.media.ExifInterface` on the file in place, null out a comprehensive set of sensitive EXIF tags, and save attributes.
3. Show a single-line toast: `Stripped X, unchanged Y, failed Z`.

## Tags stripped (47 total)

- **All GPS sub-fields**: latitude, longitude, altitude, timestamp, datestamp, processing method, area info, dest bearing/distance/lat/long, image direction, speed, track.
- **All timestamp variants**: `DATETIME`, `DATETIME_ORIGINAL`, `DATETIME_DIGITIZED`, `OFFSET_TIME`, `OFFSET_TIME_ORIGINAL`, `OFFSET_TIME_DIGITIZED`.
- **Device identification**: `MAKE`, `MODEL`, `SOFTWARE`, `BODY_SERIAL_NUMBER`, `LENS_SERIAL_NUMBER`, `CAMERA_OWNER_NAME`.
- **Author / content**: `ARTIST`, `COPYRIGHT`, `USER_COMMENT`, `IMAGE_DESCRIPTION`, `SUBJECT_LOCATION`, `SUBJECT_AREA`.

## Tags preserved

`ORIENTATION`, image dimensions, color space, ICC profile, focal length, aperture, ISO, exposure, white balance — the things that affect how the image *renders* but don't identify the user, device, or location.

## Supported formats

JPEG, HEIC/HEIF, WebP, TIFF, PNG, DNG (whatever `androidx.exifinterface 1.4.2` supports). Non-image files in the selection are silently skipped.

## Files touched

- `app/src/main/java/me/zhanghai/android/files/filejob/MetadataStripper.kt` (new, 64 lines)
- `app/src/main/java/me/zhanghai/android/files/filelist/FileListFragment.kt` (+44)
- `app/src/main/res/menu/file_list_select.xml` (+6)
- `app/src/main/res/values/strings.xml` (+3)

## Behavior notes

The operation is **destructive on the original file**. There is no confirmation dialog — this matches the existing "Rename", "Delete", "Cut/Paste" direct-effect actions. If you'd prefer a confirm prompt or a "strip to a copy in cache" variant, happy to adjust.

## Build dependency

Unchanged — `androidx.exifinterface:1.4.2` is already on the classpath (`app/build.gradle:133`).

## Tested

Selected a folder of JPEGs (some with GPS, some without), invoked "Strip metadata", toast reported `Stripped 7, unchanged 3, failed 0`, verified via `exiftool` that all GPS tags are gone from the 7 modified files and the 3 unchanged ones never had GPS to begin with.