### PR TITLE
✨ Add per-server SMB encryption option

### DIFF
--- a/app/src/main/java/me/zhanghai/android/files/provider/smb/SmbFileSystemProvider.kt
+++ b/app/src/main/java/me/zhanghai/android/files/provider/smb/SmbFileSystemProvider.kt
@@ -120,7 +120,7 @@ object SmbFileSystemProvider : FileSystemProvider(), PathObservableProvider, Sea
                 username = userInfo
                 domain = null
             }
-            val queryUri = decodedQueryByteString?.toString()?.let { Uri.parse(it) }
+            val queryUri = decodedQueryByteString?.toString()?.let { Uri.parse("?$it") }
             val encrypt = queryUri?.getQueryParameter(SmbPath.QUERY_PARAMETER_ENCRYPT)?.toBoolean()
                 ?: Authority.DEFAULT_ENCRYPT
             return Authority(host, port, username, domain, encrypt)

--- a/app/src/main/java/me/zhanghai/android/files/provider/smb/SmbFileSystemProvider.kt
+++ b/app/src/main/java/me/zhanghai/android/files/provider/smb/SmbFileSystemProvider.kt
@@ -5,6 +5,7 @@
 
 package me.zhanghai.android.files.provider.smb
 
+import android.net.Uri
 import com.hierynomus.msdtyp.AccessMask
 import java8.nio.channels.FileChannel
 import java8.nio.channels.SeekableByteChannel
@@ -33,6 +34,7 @@ import me.zhanghai.android.files.provider.common.Searchable
 import me.zhanghai.android.files.provider.common.WalkFileTreeSearchable
 import me.zhanghai.android.files.provider.common.WatchServicePathObservable
 import me.zhanghai.android.files.provider.common.decodedPathByteString
+import me.zhanghai.android.files.provider.common.decodedQueryByteString
 import me.zhanghai.android.files.provider.common.toAccessModes
 import me.zhanghai.android.files.provider.common.toByteString
 import me.zhanghai.android.files.provider.common.toCopyOptions
@@ -118,7 +120,10 @@ object SmbFileSystemProvider : FileSystemProvider(), PathObservableProvider, Sea
                 username = userInfo
                 domain = null
             }
-            return Authority(host, port, username, domain)
+            val queryUri = decodedQueryByteString?.toString()?.let { Uri.parse(it) }
+            val encrypt = queryUri?.getQueryParameter(SmbPath.QUERY_PARAMETER_ENCRYPT)?.toBoolean()
+                ?: Authority.DEFAULT_ENCRYPT
+            return Authority(host, port, username, domain, encrypt)
         }
 
     @Throws(IOException::class)

--- a/app/src/main/java/me/zhanghai/android/files/provider/smb/SmbPath.kt
+++ b/app/src/main/java/me/zhanghai/android/files/provider/smb/SmbPath.kt
@@ -5,6 +5,7 @@
 
 package me.zhanghai.android.files.provider.smb
 
+import android.net.Uri
 import android.os.Parcel
 import android.os.Parcelable
 import java8.nio.file.FileSystem
@@ -17,6 +18,7 @@ import java8.nio.file.WatchService
 import me.zhanghai.android.files.provider.common.ByteString
 import me.zhanghai.android.files.provider.common.ByteStringListPath
 import me.zhanghai.android.files.provider.common.UriAuthority
+import me.zhanghai.android.files.provider.common.toByteString
 import me.zhanghai.android.files.provider.smb.client.Authority
 import me.zhanghai.android.files.provider.smb.client.Client
 import me.zhanghai.android.files.util.readParcelable
@@ -51,6 +53,15 @@ internal class SmbPath : ByteStringListPath<SmbPath>, Client.Path {
 
     override val uriAuthority: UriAuthority
         get() = fileSystem.authority.toUriAuthority()
+
+    override val uriQuery: ByteString?
+        get() =
+            Uri.Builder().apply {
+                val authority = fileSystem.authority
+                if (authority.encrypt != Authority.DEFAULT_ENCRYPT) {
+                    appendQueryParameter(QUERY_PARAMETER_ENCRYPT, authority.encrypt.toString())
+                }
+            }.build().query?.toByteString()
 
     override val defaultDirectory: SmbPath
         get() = fileSystem.defaultDirectory
@@ -137,6 +148,8 @@ internal class SmbPath : ByteStringListPath<SmbPath>, Client.Path {
 
             override fun newArray(size: Int): Array<SmbPath?> = arrayOfNulls(size)
         }
+
+        const val QUERY_PARAMETER_ENCRYPT = "encrypt"
     }
 }
 

--- a/app/src/main/java/me/zhanghai/android/files/provider/smb/client/Authority.kt
+++ b/app/src/main/java/me/zhanghai/android/files/provider/smb/client/Authority.kt
@@ -5,18 +5,18 @@
 
 package me.zhanghai.android.files.provider.smb.client
 
+import android.os.Parcel
 import android.os.Parcelable
 import com.hierynomus.smbj.SMBClient
-import kotlinx.parcelize.Parcelize
 import me.zhanghai.android.files.provider.common.UriAuthority
 import me.zhanghai.android.files.util.takeIfNotEmpty
 
-@Parcelize
 data class Authority(
     val host: String,
     val port: Int,
     val username: String,
-    val domain: String?
+    val domain: String?,
+    val encrypt: Boolean
 ) : Parcelable {
     fun toUriAuthority(): UriAuthority {
         val userInfo = if (domain != null) "$domain\\$username" else username.takeIfNotEmpty()
@@ -26,7 +26,47 @@ data class Authority(
 
     override fun toString(): String = toUriAuthority().toString()
 
+    override fun describeContents(): Int = 0
+
+    override fun writeToParcel(dest: Parcel, flags: Int) {
+        // A version marker is written first so that authorities persisted before the encryption
+        // option was added (which started directly with the host name) can still be read back.
+        dest.writeInt(PARCEL_VERSION_MARKER)
+        dest.writeString(host)
+        dest.writeInt(port)
+        dest.writeString(username)
+        dest.writeString(domain)
+        dest.writeInt(if (encrypt) 1 else 0)
+    }
+
     companion object {
         const val DEFAULT_PORT = SMBClient.DEFAULT_PORT
+        const val DEFAULT_ENCRYPT = false
+
+        // A negative marker that can never be mistaken for the (non-negative) host name string
+        // length that legacy parcels began with, so older saved servers are read as unencrypted.
+        private const val PARCEL_VERSION_MARKER = -0x536D6201
+
+        @JvmField
+        val CREATOR = object : Parcelable.Creator<Authority> {
+            override fun createFromParcel(source: Parcel): Authority {
+                val startPosition = source.dataPosition()
+                return if (source.readInt() == PARCEL_VERSION_MARKER) {
+                    Authority(
+                        source.readString()!!, source.readInt(), source.readString()!!,
+                        source.readString(), source.readInt() != 0
+                    )
+                } else {
+                    // Legacy layout without the version marker and the encryption flag.
+                    source.setDataPosition(startPosition)
+                    Authority(
+                        source.readString()!!, source.readInt(), source.readString()!!,
+                        source.readString(), DEFAULT_ENCRYPT
+                    )
+                }
+            }
+
+            override fun newArray(size: Int): Array<Authority?> = arrayOfNulls(size)
+        }
     }
 }

--- a/app/src/main/java/me/zhanghai/android/files/provider/smb/client/Client.kt
+++ b/app/src/main/java/me/zhanghai/android/files/provider/smb/client/Client.kt
@@ -22,6 +22,7 @@ import com.hierynomus.mssmb2.messages.SMB2ChangeNotifyResponse
 import com.hierynomus.protocol.commons.EnumWithValue
 import com.hierynomus.smbj.ProgressListener
 import com.hierynomus.smbj.SMBClient
+import com.hierynomus.smbj.SmbConfig
 import com.hierynomus.smbj.auth.AuthenticationContext
 import com.hierynomus.smbj.common.SMBRuntimeException
 import com.hierynomus.smbj.session.Session
@@ -54,6 +55,11 @@ object Client {
     lateinit var authenticator: Authenticator
 
     private val client = SMBClient()
+
+    private val encryptingClient = SMBClient(SmbConfig.builder().withEncryptData(true).build())
+
+    private fun clientForAuthority(authority: Authority): SMBClient =
+        if (authority.encrypt) encryptingClient else client
 
     private val sessions = mutableMapOf<Authority, Session>()
 
@@ -607,7 +613,7 @@ object Client {
                 ?: throw ClientException("No password found for $authority")
             val hostAddress = resolveHostName(authority.host)
             val connection = try {
-                client.connect(hostAddress, authority.port)
+                clientForAuthority(authority).connect(hostAddress, authority.port)
             } catch (e: IOException) {
                 throw ClientException(e)
             }

--- a/app/src/main/java/me/zhanghai/android/files/storage/EditSmbServerFragment.kt
+++ b/app/src/main/java/me/zhanghai/android/files/storage/EditSmbServerFragment.kt
@@ -149,6 +149,7 @@ class EditSmbServerFragment : Fragment() {
                 }
                 binding.pathEdit.setText(server.relativePath)
                 binding.nameEdit.setText(server.customName)
+                binding.encryptCheck.isChecked = authority.encrypt
             } else {
                 val host = args.host
                 if (host != null) {
@@ -184,7 +185,7 @@ class EditSmbServerFragment : Fragment() {
             }
         }
         binding.nameLayout.placeholderText = if (host != null) {
-            val authority = Authority(host, port, username, domain)
+            val authority = Authority(host, port, username, domain, binding.encryptCheck.isChecked)
             if (path.isNotEmpty()) "$authority/$path" else authority.toString()
         } else {
             getString(R.string.storage_edit_smb_server_name_placeholder)
@@ -317,7 +318,7 @@ class EditSmbServerFragment : Fragment() {
             errorEdit.requestFocus()
             return null
         }
-        val authority = Authority(host!!, port!!, username!!, domain)
+        val authority = Authority(host!!, port!!, username!!, domain, binding.encryptCheck.isChecked)
         return SmbServer(args.server?.id, name, authority, password, path)
     }
 

--- a/app/src/main/res/layout/edit_smb_server_fragment.xml
+++ b/app/src/main/res/layout/edit_smb_server_fragment.xml
@@ -188,6 +188,22 @@
                                 android:inputType="textPassword" />
                         </com.google.android.material.textfield.TextInputLayout>
                     </LinearLayout>
+
+                    <CheckBox
+                        android:id="@+id/encryptCheck"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="8dp"
+                        android:text="@string/storage_edit_smb_server_encrypt"
+                        android:textAppearance="?textAppearanceListItem" />
+
+                    <TextView
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="@dimen/touch_target_size"
+                        android:text="@string/storage_edit_smb_server_encrypt_summary"
+                        android:textAppearance="?textAppearanceListItemSecondary"
+                        android:textColor="?android:textColorSecondary" />
                 </LinearLayout>
             </androidx.core.widget.NestedScrollView>
         </FrameLayout>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -652,6 +652,8 @@
     <string name="storage_edit_smb_server_username_error_empty">أدخل اسم مستخدم</string>
     <string name="storage_edit_smb_server_password">كلمة المرور</string>
     <string name="storage_edit_smb_server_domain">دومين</string>
+    <string name="storage_edit_smb_server_encrypt">تشفير SMB</string>
+    <string name="storage_edit_smb_server_encrypt_summary">تفعيل دعم تشفير SMB3. مطلوب من بعض الخوادم، ويعود إلى SMB غير المشفّر عند عدم دعمه.</string>
     <string name="storage_edit_smb_server_connect_and_add">قم بالاتصال والإضافة</string>
     <string name="storage_edit_smb_server_add">إضافة</string>
     <string name="storage_edit_webdav_server_title_edit">تعديل خادم WebDAV</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -520,6 +520,8 @@
     <string name="storage_edit_smb_server_username_error_empty">Въведете потребителско име</string>
     <string name="storage_edit_smb_server_password">Парола</string>
     <string name="storage_edit_smb_server_domain">Домейн</string>
+    <string name="storage_edit_smb_server_encrypt">SMB шифроване</string>
+    <string name="storage_edit_smb_server_encrypt_summary">Включва поддръжка на SMB3 шифроване. Изисква се от някои сървъри; връща се към нешифрован SMB, когато не се поддържа.</string>
     <string name="storage_edit_smb_server_connect_and_add">Свързване и добавяне</string>
     <string name="storage_edit_smb_server_add">Добавяне</string>
     <string name="storage_edit_webdav_server_title_edit">Променяне на сървър за WebDAV</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -476,6 +476,8 @@
     <string name="storage_edit_smb_server_username_error_empty">Introduïu un nom d\'usuari</string>
     <string name="storage_edit_smb_server_password">Contrasenya</string>
     <string name="storage_edit_smb_server_domain">Domini</string>
+    <string name="storage_edit_smb_server_encrypt">Xifratge SMB</string>
+    <string name="storage_edit_smb_server_encrypt_summary">Activa la compatibilitat amb el xifratge SMB3. El requereixen alguns servidors; recorre a SMB sense xifrar quan no és compatible.</string>
     <string name="storage_edit_smb_server_connect_and_add">Connecta i afegeix</string>
     <string name="storage_edit_smb_server_add">Afegeix</string>
     <string name="storage_edit_webdav_server_title_edit">Edita el servidor WebDAV</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -564,6 +564,8 @@
     <string name="storage_edit_smb_server_username_error_empty">Vložit uživatelské jméno</string>
     <string name="storage_edit_smb_server_password">Heslo</string>
     <string name="storage_edit_smb_server_domain">Doména</string>
+    <string name="storage_edit_smb_server_encrypt">Šifrování SMB</string>
+    <string name="storage_edit_smb_server_encrypt_summary">Zapne podporu šifrování SMB3. Vyžadováno některými servery; pokud není podporováno, použije se nešifrované SMB.</string>
     <string name="storage_edit_smb_server_connect_and_add">Připojit se a přidat</string>
     <string name="storage_edit_smb_server_add">Přidat</string>
     <string name="storage_edit_webdav_server_title_edit">Upravit server WebDAV</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -532,6 +532,8 @@
     <string name="storage_edit_smb_server_username_error_empty">Benutzernamen eingeben</string>
     <string name="storage_edit_smb_server_password">Passwort</string>
     <string name="storage_edit_smb_server_domain">Domain</string>
+    <string name="storage_edit_smb_server_encrypt">SMB-Verschlüsselung</string>
+    <string name="storage_edit_smb_server_encrypt_summary">Aktiviert die Unterstützung für SMB3-Verschlüsselung. Von einigen Servern erforderlich; greift auf unverschlüsseltes SMB zurück, wenn nicht unterstützt.</string>
     <string name="storage_edit_smb_server_connect_and_add">Verbinden und hinzufügen</string>
     <string name="storage_edit_smb_server_add">Hinzufügen</string>
     <string name="storage_edit_webdav_server_title_edit">WebDAV-Server bearbeiten</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -532,6 +532,8 @@
     <string name="storage_edit_smb_server_username_error_empty">Εισάγετε ένα όνομα χρήστη</string>
     <string name="storage_edit_smb_server_password">Κωδικός</string>
     <string name="storage_edit_smb_server_domain">Τομέας</string>
+    <string name="storage_edit_smb_server_encrypt">Κρυπτογράφηση SMB</string>
+    <string name="storage_edit_smb_server_encrypt_summary">Ενεργοποιεί την υποστήριξη κρυπτογράφησης SMB3. Απαιτείται από ορισμένους διακομιστές· επιστρέφει σε μη κρυπτογραφημένο SMB όταν δεν υποστηρίζεται.</string>
     <string name="storage_edit_smb_server_connect_and_add">Σύνδεση και προσθήκη</string>
     <string name="storage_edit_smb_server_add">Προσθήκη</string>
     <string name="storage_edit_webdav_server_title_edit">Επεξεργασία διακομιστή WebDAV</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -562,6 +562,8 @@
     <string name="storage_edit_smb_server_username_error_empty">Ingrese un nombre de usuario</string>
     <string name="storage_edit_smb_server_password">Contraseña</string>
     <string name="storage_edit_smb_server_domain">Dominio</string>
+    <string name="storage_edit_smb_server_encrypt">Cifrado SMB</string>
+    <string name="storage_edit_smb_server_encrypt_summary">Activa la compatibilidad con el cifrado SMB3. Lo requieren algunos servidores; recurre a SMB sin cifrar cuando no es compatible.</string>
     <string name="storage_edit_smb_server_connect_and_add">Conectar y añadir</string>
     <string name="storage_edit_smb_server_add">Añadir</string>
     <string name="storage_edit_webdav_server_title_edit">Editar servidor WebDAV</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -462,6 +462,8 @@
     <string name="storage_edit_smb_server_username_error_empty">یک نام کاربری وارد کنید</string>
     <string name="storage_edit_smb_server_password">گذرواژه</string>
     <string name="storage_edit_smb_server_domain">دامنه</string>
+    <string name="storage_edit_smb_server_encrypt">رمزگذاری SMB</string>
+    <string name="storage_edit_smb_server_encrypt_summary">پشتیبانی از رمزگذاری SMB3 را فعال می‌کند. برخی سرورها به آن نیاز دارند؛ در صورت پشتیبانی‌نشدن، به SMB بدون رمزگذاری بازمی‌گردد.</string>
     <string name="storage_edit_smb_server_connect_and_add">اتّصال و افزودن</string>
     <string name="storage_edit_smb_server_add">افزودن</string>
     <string name="navigation_storage_subtitle_format">%1$s آزاد از %2$s</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -451,6 +451,8 @@
     <string name="storage_edit_smb_server_username_error_empty">Syötä käyttäjänimi</string>
     <string name="storage_edit_smb_server_password">Salasana</string>
     <string name="storage_edit_smb_server_domain">Domain</string>
+    <string name="storage_edit_smb_server_encrypt">SMB-salaus</string>
+    <string name="storage_edit_smb_server_encrypt_summary">Ottaa käyttöön SMB3-salauksen tuen. Jotkin palvelimet vaativat sen; palaa salaamattomaan SMB-yhteyteen, jos sitä ei tueta.</string>
     <string name="storage_edit_smb_server_connect_and_add">Yhdistä ja lisää</string>
     <string name="storage_edit_smb_server_add">Lisää</string>
     <string name="navigation_storage_subtitle_format">%1$s/%2$s vapaana</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -564,6 +564,8 @@
     <string name="storage_edit_smb_server_username_error_empty">Entrer un nom d\'utilisateur</string>
     <string name="storage_edit_smb_server_password">Mot de passe</string>
     <string name="storage_edit_smb_server_domain">Domaine</string>
+    <string name="storage_edit_smb_server_encrypt">Chiffrement SMB</string>
+    <string name="storage_edit_smb_server_encrypt_summary">Active la prise en charge du chiffrement SMB3. Requis par certains serveurs ; revient au SMB non chiffré lorsqu\'il n\'est pas pris en charge.</string>
     <string name="storage_edit_smb_server_connect_and_add">Connecter et ajouter</string>
     <string name="storage_edit_smb_server_add">Ajouter</string>
     <string name="storage_edit_webdav_server_title_edit">Modifier le serveur WebDAV</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -466,6 +466,8 @@
     <string name="storage_edit_smb_server_username_error_empty">Adjon meg egy felhasználónevet</string>
     <string name="storage_edit_smb_server_password">Jelszót</string>
     <string name="storage_edit_smb_server_domain">Domain</string>
+    <string name="storage_edit_smb_server_encrypt">SMB-titkosítás</string>
+    <string name="storage_edit_smb_server_encrypt_summary">Bekapcsolja az SMB3-titkosítás támogatását. Egyes kiszolgálók megkövetelik; ha nem támogatott, visszavált a titkosítatlan SMB-re.</string>
     <string name="storage_edit_smb_server_connect_and_add">Kapcsolódás és hozzáadás</string>
     <string name="storage_edit_smb_server_add">Hozzáadás</string>
     <string name="navigation_storage_subtitle_format">%1$s szabad ennyiből: %2$s</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -447,6 +447,8 @@
     <string name="storage_edit_smb_server_username_error_empty">Masukkan nama pengguna</string>
     <string name="storage_edit_smb_server_password">Sandi</string>
     <string name="storage_edit_smb_server_domain">Domain</string>
+    <string name="storage_edit_smb_server_encrypt">Enkripsi SMB</string>
+    <string name="storage_edit_smb_server_encrypt_summary">Mengaktifkan dukungan enkripsi SMB3. Diperlukan oleh beberapa server; kembali ke SMB tanpa enkripsi bila tidak didukung.</string>
     <string name="storage_edit_smb_server_connect_and_add">Sambung dan tambah</string>
     <string name="storage_edit_smb_server_add">Tambah</string>
     <string name="navigation_storage_subtitle_format">%1$s kosong dari %2$s</string>

--- a/app/src/main/res/values-is/strings.xml
+++ b/app/src/main/res/values-is/strings.xml
@@ -534,6 +534,8 @@
     <string name="storage_edit_smb_server_username_error_empty">Settu inn notandanafn</string>
     <string name="storage_edit_smb_server_password">Lykilorð</string>
     <string name="storage_edit_smb_server_domain">Lén</string>
+    <string name="storage_edit_smb_server_encrypt">SMB-dulkóðun</string>
+    <string name="storage_edit_smb_server_encrypt_summary">Virkjar stuðning við SMB3-dulkóðun. Sumir netþjónar krefjast hennar; fellur aftur í ódulkóðað SMB þegar það er ekki stutt.</string>
     <string name="storage_edit_smb_server_connect_and_add">Tengjast og bæta við</string>
     <string name="storage_edit_smb_server_add">Bæta við</string>
     <string name="storage_edit_webdav_server_title_edit">Breyta WebDAV-þjóni</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -562,6 +562,8 @@
     <string name="storage_edit_smb_server_username_error_empty">Inserisci un nome utente</string>
     <string name="storage_edit_smb_server_password">Password</string>
     <string name="storage_edit_smb_server_domain">Dominio</string>
+    <string name="storage_edit_smb_server_encrypt">Crittografia SMB</string>
+    <string name="storage_edit_smb_server_encrypt_summary">Abilita il supporto alla crittografia SMB3. Richiesta da alcuni server; ripiega su SMB non crittografato quando non è supportata.</string>
     <string name="storage_edit_smb_server_connect_and_add">Connetti e aggiungi</string>
     <string name="storage_edit_smb_server_add">Aggiungi</string>
     <string name="storage_edit_webdav_server_title_edit">Modifica server WebDAV</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -592,6 +592,8 @@
     <string name="storage_edit_smb_server_username_error_empty">הזנת שם משתמש</string>
     <string name="storage_edit_smb_server_password">סיסמה</string>
     <string name="storage_edit_smb_server_domain">שם תחום</string>
+    <string name="storage_edit_smb_server_encrypt">הצפנת SMB</string>
+    <string name="storage_edit_smb_server_encrypt_summary">מפעיל תמיכה בהצפנת SMB3. נדרש על ידי שרתים מסוימים; חוזר ל-SMB לא מוצפן כשאין תמיכה.</string>
     <string name="storage_edit_smb_server_connect_and_add">התחברות והוספה</string>
     <string name="storage_edit_smb_server_add">הוספה</string>
     <string name="storage_edit_webdav_server_title_edit">עריכת שרת WebDAV</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -502,6 +502,8 @@
     <string name="storage_edit_smb_server_username_error_empty">ユーザー名を入力してください</string>
     <string name="storage_edit_smb_server_password">パスワード</string>
     <string name="storage_edit_smb_server_domain">ドメイン</string>
+    <string name="storage_edit_smb_server_encrypt">SMB 暗号化</string>
+    <string name="storage_edit_smb_server_encrypt_summary">SMB3 暗号化のサポートを有効にします。一部のサーバーで必要です。対応していない場合は暗号化なしの SMB にフォールバックします。</string>
     <string name="storage_edit_smb_server_connect_and_add">接続して追加</string>
     <string name="storage_edit_smb_server_add">追加</string>
     <string name="storage_edit_webdav_server_title_edit">WebDAV サーバーを編集</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -502,6 +502,8 @@
     <string name="storage_edit_smb_server_username_error_empty">사용자 이름을 입력하세요</string>
     <string name="storage_edit_smb_server_password">비밀번호</string>
     <string name="storage_edit_smb_server_domain">도메인</string>
+    <string name="storage_edit_smb_server_encrypt">SMB 암호화</string>
+    <string name="storage_edit_smb_server_encrypt_summary">SMB3 암호화 지원을 사용합니다. 일부 서버에서 필요하며, 지원되지 않으면 암호화되지 않은 SMB로 대체됩니다.</string>
     <string name="storage_edit_smb_server_connect_and_add">연결 및 추가</string>
     <string name="storage_edit_smb_server_add">추가</string>
     <string name="storage_edit_webdav_server_title_edit">WebDAV 서버 편집</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -524,6 +524,8 @@
     <string name="storage_edit_smb_server_username_error_empty">Įvesti naudotojo vardą</string>
     <string name="storage_edit_smb_server_password">Slaptažodis</string>
     <string name="storage_edit_smb_server_domain">Domenas</string>
+    <string name="storage_edit_smb_server_encrypt">SMB šifravimas</string>
+    <string name="storage_edit_smb_server_encrypt_summary">Įjungia SMB3 šifravimo palaikymą. Reikalingas kai kuriems serveriams; jei nepalaikoma, grįžtama prie nešifruoto SMB.</string>
     <string name="storage_edit_smb_server_connect_and_add">Prisijungti ir pridėti</string>
     <string name="storage_edit_smb_server_add">Pridėti</string>
     <string name="navigation_storage_subtitle_format">%1$s laisva iš %2$s</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -532,6 +532,8 @@
     <string name="storage_edit_smb_server_username_error_empty">Skriv inn et brukernavn</string>
     <string name="storage_edit_smb_server_password">Passord</string>
     <string name="storage_edit_smb_server_domain">Domene</string>
+    <string name="storage_edit_smb_server_encrypt">SMB-kryptering</string>
+    <string name="storage_edit_smb_server_encrypt_summary">Slår på støtte for SMB3-kryptering. Kreves av enkelte tjenere; faller tilbake til ukryptert SMB når det ikke støttes.</string>
     <string name="storage_edit_smb_server_connect_and_add">Koble til og legg til</string>
     <string name="storage_edit_smb_server_add">Legg til</string>
     <string name="storage_edit_webdav_server_title_edit">Rediger WebDAV-tjener</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -532,6 +532,8 @@
     <string name="storage_edit_smb_server_username_error_empty">Voer een gebruikersnaam in</string>
     <string name="storage_edit_smb_server_password">Wachtwoord</string>
     <string name="storage_edit_smb_server_domain">Domein</string>
+    <string name="storage_edit_smb_server_encrypt">SMB-versleuteling</string>
+    <string name="storage_edit_smb_server_encrypt_summary">Schakelt ondersteuning voor SMB3-versleuteling in. Vereist door sommige servers; valt terug op onversleutelde SMB wanneer dit niet wordt ondersteund.</string>
     <string name="storage_edit_smb_server_connect_and_add">Verbinden en toevoegen</string>
     <string name="storage_edit_smb_server_add">Toevoegen</string>
     <string name="storage_edit_webdav_server_title_edit">WebDAV-server bewerken</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -592,6 +592,8 @@
     <string name="storage_edit_smb_server_username_error_empty">Wprowadź nazwę użytkownika</string>
     <string name="storage_edit_smb_server_password">Hasło</string>
     <string name="storage_edit_smb_server_domain">Domena</string>
+    <string name="storage_edit_smb_server_encrypt">Szyfrowanie SMB</string>
+    <string name="storage_edit_smb_server_encrypt_summary">Włącza obsługę szyfrowania SMB3. Wymagane przez niektóre serwery; w razie braku obsługi używa nieszyfrowanego SMB.</string>
     <string name="storage_edit_smb_server_connect_and_add">Połącz i dodaj</string>
     <string name="storage_edit_smb_server_add">Dodaj</string>
     <string name="storage_edit_webdav_server_title_edit">Edytuj serwer WebDAV</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -504,6 +504,8 @@
     <string name="storage_edit_smb_server_username_error_empty">Insira o nome do usuário</string>
     <string name="storage_edit_smb_server_password">Senha</string>
     <string name="storage_edit_smb_server_domain">Domínio</string>
+    <string name="storage_edit_smb_server_encrypt">Criptografia SMB</string>
+    <string name="storage_edit_smb_server_encrypt_summary">Ativa o suporte à criptografia SMB3. Exigida por alguns servidores; recorre ao SMB sem criptografia quando não há suporte.</string>
     <string name="storage_edit_smb_server_connect_and_add">Conecte e adicione</string>
     <string name="storage_edit_smb_server_add">Add</string>
     <string name="storage_edit_webdav_server_title_edit">Editar servidor WebDAV</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -506,6 +506,8 @@
     <string name="storage_edit_smb_server_username_error_empty">Introduza um nome de utilizador</string>
     <string name="storage_edit_smb_server_password">Palavra-passe</string>
     <string name="storage_edit_smb_server_domain">Domínio</string>
+    <string name="storage_edit_smb_server_encrypt">Encriptação SMB</string>
+    <string name="storage_edit_smb_server_encrypt_summary">Ativa o suporte à encriptação SMB3. Exigida por alguns servidores; recorre ao SMB sem encriptação quando não é suportada.</string>
     <string name="storage_edit_smb_server_connect_and_add">Conectar e adicionar</string>
     <string name="storage_edit_smb_server_add">Adicionar</string>
     <string name="storage_edit_webdav_server_title_edit">Editar servidor WebDAV</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -503,6 +503,8 @@
     <string name="storage_edit_smb_server_username_error_empty">Introdu un nume de utilizator</string>
     <string name="storage_edit_smb_server_password">Parolă</string>
     <string name="storage_edit_smb_server_domain">Domeniu</string>
+    <string name="storage_edit_smb_server_encrypt">Criptare SMB</string>
+    <string name="storage_edit_smb_server_encrypt_summary">Activează suportul pentru criptarea SMB3. Necesară pentru unele servere; revine la SMB necriptat când nu este acceptată.</string>
     <string name="storage_edit_smb_server_connect_and_add">Conectează și adaugă</string>
     <string name="storage_edit_smb_server_add">Adaugă</string>
     <string name="navigation_storage_subtitle_format">%1$s liber din %2$s</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -594,6 +594,8 @@
     <string name="storage_edit_smb_server_username_error_empty">Введите имя пользователя</string>
     <string name="storage_edit_smb_server_password">Пароль</string>
     <string name="storage_edit_smb_server_domain">Домен</string>
+    <string name="storage_edit_smb_server_encrypt">Шифрование SMB</string>
+    <string name="storage_edit_smb_server_encrypt_summary">Включает поддержку шифрования SMB3. Требуется некоторыми серверами; при отсутствии поддержки используется незашифрованный SMB.</string>
     <string name="storage_edit_smb_server_connect_and_add">Добавить и соединиться</string>
     <string name="storage_edit_smb_server_add">Добавить</string>
     <string name="storage_edit_webdav_server_title_edit">Редактировать WebDAV сервер</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -441,6 +441,8 @@
     <string name="storage_edit_smb_server_username_error_empty">Bir kullanıcı adı gir</string>
     <string name="storage_edit_smb_server_password">Şifre</string>
     <string name="storage_edit_smb_server_domain">Alan adı</string>
+    <string name="storage_edit_smb_server_encrypt">SMB şifrelemesi</string>
+    <string name="storage_edit_smb_server_encrypt_summary">SMB3 şifreleme desteğini etkinleştirir. Bazı sunucular tarafından gereklidir; desteklenmediğinde şifrelenmemiş SMB\'ye geri döner.</string>
     <string name="storage_edit_smb_server_connect_and_add">Bağlan ve ekle</string>
     <string name="storage_edit_smb_server_add">Ekle</string>
     <string name="navigation_storage_subtitle_format">%2$s alandan %1$s boş</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -594,6 +594,8 @@
     <string name="storage_edit_smb_server_username_error_empty">Введіть ім\'я користувача</string>
     <string name="storage_edit_smb_server_password">Пароль</string>
     <string name="storage_edit_smb_server_domain">Домен</string>
+    <string name="storage_edit_smb_server_encrypt">Шифрування SMB</string>
+    <string name="storage_edit_smb_server_encrypt_summary">Вмикає підтримку шифрування SMB3. Потрібне деяким серверам; за відсутності підтримки використовується незашифрований SMB.</string>
     <string name="storage_edit_smb_server_connect_and_add">З\'єднатися та додати</string>
     <string name="storage_edit_smb_server_add">Додати</string>
     <string name="storage_edit_webdav_server_title_edit">Змінити WebDAV сервер</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -432,6 +432,8 @@
     <string name="storage_edit_smb_server_username_error_empty">Nhập tên người dùng</string>
     <string name="storage_edit_smb_server_password">Mật khẩu</string>
     <string name="storage_edit_smb_server_domain">Miền</string>
+    <string name="storage_edit_smb_server_encrypt">Mã hóa SMB</string>
+    <string name="storage_edit_smb_server_encrypt_summary">Bật hỗ trợ mã hóa SMB3. Một số máy chủ yêu cầu; quay lại SMB không mã hóa khi không được hỗ trợ.</string>
     <string name="storage_edit_smb_server_connect_and_add">Kết nối và thêm</string>
     <string name="storage_edit_smb_server_add">Thêm</string>
     <string name="navigation_storage_subtitle_format">%1$s trống trong số %2$s</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -501,6 +501,8 @@
     <string name="storage_edit_smb_server_username_error_empty">输入用户名</string>
     <string name="storage_edit_smb_server_password">密码</string>
     <string name="storage_edit_smb_server_domain">域</string>
+    <string name="storage_edit_smb_server_encrypt">SMB 加密</string>
+    <string name="storage_edit_smb_server_encrypt_summary">启用 SMB3 加密支持。某些服务器需要；不支持时回退到未加密的 SMB。</string>
     <string name="storage_edit_smb_server_connect_and_add">连接并添加</string>
     <string name="storage_edit_smb_server_add">添加</string>
     <string name="storage_edit_webdav_server_title_edit">编辑 WebDAV 服务器</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -501,6 +501,8 @@
     <string name="storage_edit_smb_server_username_error_empty">輸入使用者名稱</string>
     <string name="storage_edit_smb_server_password">密碼</string>
     <string name="storage_edit_smb_server_domain">網域</string>
+    <string name="storage_edit_smb_server_encrypt">SMB 加密</string>
+    <string name="storage_edit_smb_server_encrypt_summary">啟用 SMB3 加密支援。某些伺服器需要；不支援時會退回未加密的 SMB。</string>
     <string name="storage_edit_smb_server_connect_and_add">連線並新增</string>
     <string name="storage_edit_smb_server_add">新增</string>
     <string name="storage_edit_webdav_server_title_edit">編輯 WebDAV 伺服器</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -638,6 +638,8 @@
     <string name="storage_edit_smb_server_username_error_empty">Enter a username</string>
     <string name="storage_edit_smb_server_password">Password</string>
     <string name="storage_edit_smb_server_domain">Domain</string>
+    <string name="storage_edit_smb_server_encrypt">SMB encryption</string>
+    <string name="storage_edit_smb_server_encrypt_summary">Enable SMB3 encryption support. Required by some servers; falls back to unencrypted SMB when unsupported.</string>
     <string name="storage_edit_smb_server_connect_and_add">Connect and add</string>
     <string name="storage_edit_smb_server_add">Add</string>
     <string name="storage_edit_webdav_server_title_edit">Edit WebDAV server</string>


### PR DESCRIPTION
## What changed ✨

This adds a new per-server SMB encryption option for SMB connections.

By default, nothing changes:
- existing SMB servers keep the current behavior
- new SMB servers use the current non-encrypted SMBJ configuration unless the option is enabled

When enabled, the app uses SMBJ with `SmbConfig.builder().withEncryptData(true).build()`, which allows connecting to SMB3 servers or shares that require encryption.

## Why 🔐

This is related to:
- #486
- #1271

#1271 already proposed enabling SMB encryption support globally, but this PR takes a more conservative approach: SMB encryption is now controlled per server instead of being enabled for every SMB connection.

This should help with servers such as:
- Samba shares with mandatory SMB encryption
- Windows shares requiring SMB encryption
- NAS devices enforcing encrypted SMB3 sessions

## Testing ✅

I tested this myself in real conditions on Android with a server requiring SMB encryption.

I also verified that the option is saved per server and that the default behavior remains unchanged when the option is disabled.

## Translations 🌍

I added translations for all currently available app languages.