### PR TITLE
Optimize SFTP writes

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -108,7 +108,7 @@ repositories {
 }
 dependencies {
     // We need https://github.com/bitfireAT/dav4jvm/commit/c1bc14348831bcdb00f3a6eec4859b81c7dc3728
-    implementation('com.github.bitfireAT:dav4jvm:02fe1a95e6') {
+    implementation('com.github.bitfireAT:dav4jvm:02fe1a95e6b86e323bec3784d7d2fe2d4081dde6') {
         exclude group: 'org.ogce', module: 'xpp3'
     }
     implementation 'com.github.chrisbanes:PhotoView:2.3.0'

--- a/app/src/main/java/me/zhanghai/android/files/provider/common/ForeignCopyMove.kt
+++ b/app/src/main/java/me/zhanghai/android/files/provider/common/ForeignCopyMove.kt
@@ -54,23 +54,23 @@ internal object ForeignCopyMove {
                     )
                     var successful = false
                     try {
-                        inputStream.copyTo(
-                            outputStream, copyOptions.progressIntervalMillis,
-                            copyOptions.progressListener
-                        )
+                        try {
+                            inputStream.copyTo(
+                                outputStream, copyOptions.progressIntervalMillis,
+                                copyOptions.progressListener
+                            )
+                        } finally {
+                            outputStream.close()
+                        }
                         successful = true
                     } finally {
-                        try {
-                            outputStream.close()
-                        } finally {
-                            if (!successful) {
-                                try {
-                                    target.deleteIfExists()
-                                } catch (e: IOException) {
-                                    e.printStackTrace()
-                                } catch (e: UnsupportedOperationException) {
-                                    e.printStackTrace()
-                                }
+                        if (!successful) {
+                            try {
+                                target.deleteIfExists()
+                            } catch (e: IOException) {
+                                e.printStackTrace()
+                            } catch (e: UnsupportedOperationException) {
+                                e.printStackTrace()
                             }
                         }
                     }

--- a/app/src/main/java/me/zhanghai/android/files/provider/common/InputStreamExtensions.kt
+++ b/app/src/main/java/me/zhanghai/android/files/provider/common/InputStreamExtensions.kt
@@ -10,6 +10,8 @@ import java.io.InputStream
 import java.io.InterruptedIOException
 import java.io.OutputStream
 
+private const val COPY_BUFFER_SIZE = 16 * 1024
+
 // Can handle ProgressCopyOption.
 @Throws(IOException::class)
 fun InputStream.copyTo(
@@ -17,7 +19,7 @@ fun InputStream.copyTo(
     intervalMillis: Long,
     listener: ((Long) -> Unit)?
 ) {
-    val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+    val buffer = ByteArray(COPY_BUFFER_SIZE)
     var lastProgressMillis = System.currentTimeMillis()
     var copiedSize = 0L
     while (true) {

--- a/app/src/main/java/me/zhanghai/android/files/provider/sftp/SftpCopyMove.kt
+++ b/app/src/main/java/me/zhanghai/android/files/provider/sftp/SftpCopyMove.kt
@@ -6,6 +6,7 @@
 package me.zhanghai.android.files.provider.sftp
 
 import java.io.IOException
+import java.io.InterruptedIOException
 import java.time.Instant
 import java8.nio.file.FileAlreadyExistsException
 import java8.nio.file.FileSystemException
@@ -14,7 +15,6 @@ import java8.nio.file.StandardCopyOption
 import me.zhanghai.android.files.provider.common.CopyOptions
 import me.zhanghai.android.files.provider.common.copyTo
 import me.zhanghai.android.files.provider.common.newInputStream
-import me.zhanghai.android.files.provider.common.newOutputStream
 import me.zhanghai.android.files.provider.sftp.client.Client
 import me.zhanghai.android.files.provider.sftp.client.ClientException
 import me.zhanghai.android.files.util.enumSetOf
@@ -94,29 +94,33 @@ internal object SftpCopyMove {
                         targetFlags += OpenMode.EXCL
                     }
                     val targetOutputStream = try {
-                        Client.openByteChannel(target, targetFlags, sourceModeAttributes)
+                        Client.openOutputStream(target, targetFlags, sourceModeAttributes)
                     } catch (e: ClientException) {
                         throw e.toFileSystemException(target.toString())
-                    }.newOutputStream()
+                    }
                     var successful = false
                     try {
-                        sourceInputStream.copyTo(
-                            targetOutputStream, copyOptions.progressIntervalMillis,
-                            copyOptions.progressListener
-                        )
+                        try {
+                            sourceInputStream.copyTo(
+                                targetOutputStream, copyOptions.progressIntervalMillis,
+                                copyOptions.progressListener
+                            )
+                        } finally {
+                            try {
+                                targetOutputStream.close()
+                            } catch (e: InterruptedIOException) {
+                                throw e
+                            } catch (e: IOException) {
+                                throw ClientException(e).toFileSystemException(target.toString())
+                            }
+                        }
                         successful = true
                     } finally {
-                        try {
-                            targetOutputStream.close()
-                        } catch (e: IOException) {
-                            throw ClientException(e).toFileSystemException(target.toString())
-                        } finally {
-                            if (!successful) {
-                                try {
-                                    Client.remove(target)
-                                } catch (e: ClientException) {
-                                    e.printStackTrace()
-                                }
+                        if (!successful) {
+                            try {
+                                Client.remove(target)
+                            } catch (e: ClientException) {
+                                e.printStackTrace()
                             }
                         }
                     }

--- a/app/src/main/java/me/zhanghai/android/files/provider/sftp/SftpFileSystemProvider.kt
+++ b/app/src/main/java/me/zhanghai/android/files/provider/sftp/SftpFileSystemProvider.kt
@@ -18,6 +18,7 @@ import java8.nio.file.LinkOption
 import java8.nio.file.OpenOption
 import java8.nio.file.Path
 import java8.nio.file.ProviderMismatchException
+import java8.nio.file.StandardOpenOption
 import java8.nio.file.attribute.BasicFileAttributes
 import java8.nio.file.attribute.FileAttribute
 import java8.nio.file.attribute.FileAttributeView
@@ -31,6 +32,7 @@ import me.zhanghai.android.files.provider.common.Searchable
 import me.zhanghai.android.files.provider.common.WalkFileTreeSearchable
 import me.zhanghai.android.files.provider.common.WatchServicePathObservable
 import me.zhanghai.android.files.provider.common.decodedPathByteString
+import me.zhanghai.android.files.provider.common.newOutputStream
 import me.zhanghai.android.files.provider.common.toAccessModes
 import me.zhanghai.android.files.provider.common.toByteString
 import me.zhanghai.android.files.provider.common.toCopyOptions
@@ -43,6 +45,7 @@ import me.zhanghai.android.files.provider.sftp.client.SecurityProviderHelper
 import me.zhanghai.android.files.util.enumSetOf
 import net.schmizz.sshj.sftp.OpenMode
 import java.io.IOException
+import java.io.OutputStream
 import java.net.URI
 
 object SftpFileSystemProvider : FileSystemProvider(), PathObservableProvider, Searchable {
@@ -120,6 +123,29 @@ object SftpFileSystemProvider : FileSystemProvider(), PathObservableProvider, Se
     ): FileChannel {
         file as? SftpPath ?: throw ProviderMismatchException(file.toString())
         throw UnsupportedOperationException()
+    }
+
+    @Throws(IOException::class)
+    override fun newOutputStream(file: Path, vararg options: OpenOption): OutputStream {
+        file as? SftpPath ?: throw ProviderMismatchException(file.toString())
+        val optionsSet = mutableSetOf(*options)
+        if (optionsSet.isEmpty()) {
+            optionsSet += StandardOpenOption.CREATE
+            optionsSet += StandardOpenOption.TRUNCATE_EXISTING
+        }
+        optionsSet += StandardOpenOption.WRITE
+        val openOptions = optionsSet.toOpenOptions()
+        val flags = openOptions.toSftpFlags()
+        val attributes = PosixFileMode.CREATE_FILE_DEFAULT.toSftpAttributes()
+        return try {
+            if (openOptions.append) {
+                Client.openByteChannel(file, flags, attributes).newOutputStream()
+            } else {
+                Client.openOutputStream(file, flags, attributes)
+            }
+        } catch (e: ClientException) {
+            throw e.toFileSystemException(file.toString())
+        }
     }
 
     @Throws(IOException::class)

--- a/app/src/main/java/me/zhanghai/android/files/provider/sftp/client/Client.kt
+++ b/app/src/main/java/me/zhanghai/android/files/provider/sftp/client/Client.kt
@@ -7,6 +7,7 @@ package me.zhanghai.android.files.provider.sftp.client
 
 import java8.nio.channels.SeekableByteChannel
 import me.zhanghai.android.files.provider.common.LocalWatchService
+import me.zhanghai.android.files.provider.common.NotifyEntryModifiedOutputStream
 import me.zhanghai.android.files.provider.common.NotifyEntryModifiedSeekableByteChannel
 import me.zhanghai.android.files.util.closeSafe
 import net.schmizz.sshj.SSHClient
@@ -21,6 +22,7 @@ import net.schmizz.sshj.transport.TransportException
 import net.schmizz.sshj.transport.verification.PromiscuousVerifier
 import net.schmizz.sshj.userauth.UserAuthException
 import java.io.IOException
+import java.io.OutputStream
 import java.util.Collections
 import java.util.WeakHashMap
 import java8.nio.file.Path as Java8Path
@@ -89,6 +91,18 @@ object Client {
         val file = open(path, flags, attributes)
         return NotifyEntryModifiedSeekableByteChannel(
             FileByteChannel(file, flags.contains(OpenMode.APPEND)), path as Java8Path
+        )
+    }
+
+    @Throws(ClientException::class)
+    fun openOutputStream(
+        path: Path,
+        flags: Set<OpenMode>,
+        attributes: FileAttributes
+    ): OutputStream {
+        val file = open(path, flags, attributes)
+        return NotifyEntryModifiedOutputStream(
+            PipelinedFileOutputStream(file), path as Java8Path
         )
     }
 

--- a/app/src/main/java/me/zhanghai/android/files/provider/sftp/client/PipelinedFileOutputStream.kt
+++ b/app/src/main/java/me/zhanghai/android/files/provider/sftp/client/PipelinedFileOutputStream.kt
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2026 Hai Zhang <dreaming.in.code.zh@gmail.com>
+ * All Rights Reserved.
+ */
+
+package me.zhanghai.android.files.provider.sftp.client
+
+import me.zhanghai.android.files.util.findCauseByClass
+import net.schmizz.concurrent.Promise
+import net.schmizz.sshj.sftp.RemoteFile
+import net.schmizz.sshj.sftp.RemoteFileAccessor
+import net.schmizz.sshj.sftp.Response
+import net.schmizz.sshj.sftp.SFTPException
+import java.io.IOException
+import java.io.InterruptedIOException
+import java.io.OutputStream
+import java.nio.channels.AsynchronousCloseException
+import java.util.ArrayDeque
+import java.util.concurrent.TimeUnit
+
+internal class PipelinedFileOutputStream(private val file: RemoteFile) : OutputStream() {
+    private val requester = RemoteFileAccessor.getRequester(file)
+    private val maxWriteSize =
+        requester.subsystem.remoteMaxPacketSize - file.outgoingPacketOverhead
+    private val pendingWrites =
+        ArrayDeque<Promise<Response, SFTPException>>(MAX_PENDING_WRITES)
+    private val singleByte = ByteArray(1)
+
+    private var fileOffset = 0L
+    private var failure: IOException? = null
+    private var isClosed = false
+
+    init {
+        check(maxWriteSize > 0)
+    }
+
+    @Throws(IOException::class)
+    override fun write(value: Int) {
+        singleByte[0] = value.toByte()
+        write(singleByte, 0, 1)
+    }
+
+    @Throws(IOException::class)
+    override fun write(buffer: ByteArray, offset: Int, length: Int) {
+        ensureOpen()
+        if (offset < 0 || length < 0 || offset > buffer.size - length) {
+            throw IndexOutOfBoundsException()
+        }
+        failure?.let { throw it }
+        var currentOffset = offset
+        var remaining = length
+        while (remaining > 0) {
+            if (pendingWrites.size == MAX_PENDING_WRITES) {
+                awaitNextWrite()
+                failure?.let { throw it }
+            }
+            val writeSize = remaining.coerceAtMost(maxWriteSize)
+            val promise = try {
+                RemoteFileAccessor.asyncWrite(
+                    file, fileOffset, buffer, currentOffset, writeSize
+                )
+            } catch (e: IOException) {
+                recordFailure(e)
+                throw failure!!
+            }
+            pendingWrites.addLast(promise)
+            fileOffset += writeSize
+            currentOffset += writeSize
+            remaining -= writeSize
+        }
+    }
+
+    @Throws(IOException::class)
+    override fun flush() {
+        ensureOpen()
+        drainPendingWrites()
+        failure?.let { throw it }
+    }
+
+    @Throws(IOException::class)
+    override fun close() {
+        if (isClosed) {
+            return
+        }
+        isClosed = true
+        drainPendingWrites()
+        try {
+            file.close()
+        } catch (e: SFTPException) {
+            if (e.statusCode != Response.StatusCode.NO_SUCH_FILE) {
+                recordFailure(e)
+            }
+        } catch (e: IOException) {
+            recordFailure(e)
+        }
+        failure?.let { throw it }
+    }
+
+    private fun drainPendingWrites() {
+        while (pendingWrites.isNotEmpty()) {
+            awaitNextWrite()
+        }
+    }
+
+    private fun awaitNextWrite() {
+        val promise = pendingWrites.removeFirst()
+        try {
+            promise.retrieve(requester.timeoutMs.toLong(), TimeUnit.MILLISECONDS)
+                .ensureStatusPacketIsOK()
+        } catch (e: IOException) {
+            recordFailure(e)
+        }
+    }
+
+    private fun recordFailure(exception: IOException) {
+        val exception = exception.toStreamException()
+        val failure = failure
+        if (failure == null) {
+            this.failure = exception
+        } else if (failure !== exception) {
+            failure.addSuppressed(exception)
+        }
+    }
+
+    private fun IOException.toStreamException(): IOException =
+        when {
+            this is SFTPException && statusCode == Response.StatusCode.INVALID_HANDLE ->
+                AsynchronousCloseException().apply { initCause(this@toStreamException) }
+            findCauseByClass<InterruptedException>() != null -> {
+                Thread.interrupted()
+                InterruptedIOException().apply { initCause(this@toStreamException) }
+            }
+            else -> this
+        }
+
+    @Throws(IOException::class)
+    private fun ensureOpen() {
+        if (isClosed) {
+            throw IOException("Stream closed")
+        }
+    }
+
+    companion object {
+        private const val MAX_PENDING_WRITES = 8
+    }
+}

--- a/app/src/main/java/net/schmizz/sshj/sftp/RemoteFileAccessor.java
+++ b/app/src/main/java/net/schmizz/sshj/sftp/RemoteFileAccessor.java
@@ -21,6 +21,13 @@ public class RemoteFileAccessor {
     }
 
     @NonNull
+    public static Promise<Response, SFTPException> asyncWrite(@NonNull RemoteFile file, long offset,
+                                                               @NonNull byte[] data, int dataOffset,
+                                                               int length) throws IOException {
+        return file.asyncWrite(offset, data, dataOffset, length);
+    }
+
+    @NonNull
     public static SFTPEngine getRequester(@NonNull RemoteFile file) {
         return file.requester;
     }


### PR DESCRIPTION
I noticed that SFTP writes were extremely slow with MaterialFiles, especially over wireguard networks.  After some digging, it turned out that they were bottlenecked by syncronous writes capped by RTT latency.  This PR allows for pipelined writes, which leads to massively improved performance.  Over my cell phone connection, writes went up from around 150-200 KB/s to over 1.5MB/s.

I think they can be optimized further by being smarter, but this alone gives x10 improvement over the current state.